### PR TITLE
fix: use GitHub raw URL for logo to display on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="assets/images/ondine-logo.png" alt="Ondine Logo" width="600"/>
+  <img src="https://raw.githubusercontent.com/ptimizeroracle/ondine/main/assets/images/ondine-logo.png" alt="Ondine Logo" width="600"/>
 
   # LLM Dataset Engine
 </div>


### PR DESCRIPTION
## Problem
PyPI doesn't display the logo because it uses a local file path (`assets/images/ondine-logo.png`) which PyPI can't access.

## Solution
Changed to GitHub raw URL: `https://raw.githubusercontent.com/ptimizeroracle/ondine/main/assets/images/ondine-logo.png`

## Result
- ✅ Logo will display correctly on PyPI
- ✅ Logo still works in GitHub README
- ✅ Logo still works in documentation

## Testing
After merge, the logo will appear on the next PyPI release (or we can trigger a patch release 1.2.1).