### PR TITLE
fix: Update release workflow to use uv run semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,21 +38,22 @@ jobs:
 
       - name: Python Semantic Release
         id: release
-        uses: python-semantic-release/python-semantic-release@v9.14.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          git_committer_name: "github-actions[bot]"
-          git_committer_email: "github-actions[bot]@users.noreply.github.com"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Run semantic-release with uv (ensures uv is in PATH for build command)
+          uv run semantic-release version
+
+          # Check if a release was created
+          if [ -f .semantic-release-version ]; then
+            echo "released=true" >> $GITHUB_OUTPUT
+            echo "tag=$(cat .semantic-release-version)" >> $GITHUB_OUTPUT
+          else
+            echo "released=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Publish to PyPI (if enabled)
         if: steps.release.outputs.released == 'true' && false  # Disabled by default
         run: |
           uv build
           uv publish --token ${{ secrets.PYPI_TOKEN }}
-
-      - name: Publish release notes
-        if: steps.release.outputs.released == 'true'
-        uses: python-semantic-release/upload-to-gh-release@main
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.release.outputs.tag }}


### PR DESCRIPTION
## Fix for PR #28

Fixes the release workflow failure where `uv build` command wasn't found.

## Problem

The previous workflow used the `python-semantic-release` GitHub Action, which runs semantic-release in its own environment where `uv` isn't available.

## Solution

Run semantic-release directly with `uv run semantic-release version`:
- This ensures `uv` is in PATH when build_command runs
- Simplified workflow (removed redundant steps)
- Proper output detection for downstream steps

## Changes

```.github/workflows/release.yml```
- Replaced GitHub Action with direct command: `uv run semantic-release version`
- Added GH_TOKEN environment variable
- Added output detection for released/tag status
- Removed upload-to-gh-release step (semantic-release handles it automatically)

## Testing

This will be tested when merged - the workflow should:
1. Detect version 1.3.0 (from feat commits)
2. Run `uv build` successfully
3. Update pyproject.toml and CHANGELOG.md
4. Create tag v1.3.0
5. Create GitHub release

## Related

- Fixes #28 (automated versioning workflow failure)