### PR TITLE
fix: Make CLI version test dynamic instead of hardcoded

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -27,9 +27,11 @@ class TestCLI:
 
     def test_cli_version(self):
         """Test CLI version command."""
+        from ondine import __version__
+
         result = self.runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
-        assert "1.0.3" in result.output
+        assert __version__ in result.output
 
     def test_process_help(self):
         """Test process command help."""

--- a/uv.lock
+++ b/uv.lock
@@ -3277,7 +3277,7 @@ wheels = [
 
 [[package]]
 name = "ondine"
-version = "1.2.1"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes test failure after v1.3.0 release.

## Problem
- test_cli_version was hardcoded to check for '1.0.3'
- Version is now 1.3.0 (from automated release)
- Test failed on CI

## Solution
- Import __version__ from ondine package
- Check for __version__ in output (dynamic)
- Test now works with any version

## Test Results
- ✅ All 435 tests passing
- ✅ 60% coverage maintained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced CLI version command validation to dynamically verify the package version against the actual installed version, improving test reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->