### PR TITLE
fix: Make CLI version test dynamic and restore PyPI workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,66 @@
+name: Release to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    environment: Ondine  # Use the Ondine environment with PYPI_API_TOKEN
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
+    - name: Verify version matches tag
+      if: github.event_name == 'release'
+      run: |
+        TAG_VERSION=${GITHUB_REF#refs/tags/v}
+        PACKAGE_VERSION=$(grep '^version = ' pyproject.toml | cut -d'"' -f2)
+        if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
+          echo "Error: Tag version ($TAG_VERSION) does not match package version ($PACKAGE_VERSION)"
+          exit 1
+        fi
+        echo "✅ Version check passed: $TAG_VERSION"
+
+    - name: Build package
+      run: |
+        uv build
+        echo "📦 Built package:"
+        ls -lh dist/
+
+    - name: Verify package contents
+      run: |
+        echo "📋 Checking package contents..."
+        tar -tzf dist/*.tar.gz | grep -E "(LICENSE|CHANGELOG|README)" || echo "Warning: Some docs missing"
+        echo "✅ Package verification complete"
+
+    - name: Publish to PyPI
+      env:
+        UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        echo "Publishing to PyPI..."
+        uv publish
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-packages
+        path: dist/
+        retention-days: 30

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -27,9 +27,11 @@ class TestCLI:
 
     def test_cli_version(self):
         """Test CLI version command."""
+        from ondine import __version__
+
         result = self.runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
-        assert "1.0.3" in result.output
+        assert __version__ in result.output
 
     def test_process_help(self):
         """Test process command help."""

--- a/uv.lock
+++ b/uv.lock
@@ -3277,7 +3277,7 @@ wheels = [
 
 [[package]]
 name = "ondine"
-version = "1.2.1"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Two Critical Fixes

### 1. Fix CLI Version Test
- test_cli_version was hardcoded to check for '1.0.3'
- Now imports __version__ dynamically
- Works with any version (won't break on version bumps)

### 2. Restore PyPI Publishing Workflow
- Added publish-pypi.yml (was accidentally removed)
- Triggers on release published (not on push to main)
- Publishes to PyPI automatically when release is created

## Why PyPI Didn't Publish for v1.3.0

The PyPI workflow was missing when v1.3.0 was released. After this PR merges:
- Future releases will automatically publish to PyPI
- v1.3.0 can be manually re-published if needed

## How It Works

**Two separate workflows:**
1. **release.yml** - Release Please creates release PR
2. **publish-pypi.yml** - Publishes to PyPI when release is created

## Test Results
- ✅ All 435 tests passing
- ✅ 60% coverage maintained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated release and publishing to PyPI enabled via GitHub Actions workflow
  
* **Tests**
  * Improved version verification in test suite for enhanced reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->