### PR TITLE
chore: harden CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Quick checks for feature branches - runs on every push
   quick-check:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,7 +3,16 @@ name: Release to PyPI
 on:
   release:
     types: [published]
-  workflow_dispatch:  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag to publish (for example: v1.4.0)"
+        required: true
+        type: string
+
+concurrency:
+  group: publish-pypi
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -15,8 +24,17 @@ jobs:
     environment: Ondine  # Use the Ondine environment with PYPI_API_TOKEN
 
     steps:
-    - name: Checkout code
+    - name: Checkout release ref
+      if: github.event_name == 'release'
       uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.release.tag_name }}
+
+    - name: Checkout manual release tag
+      if: github.event_name == 'workflow_dispatch'
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.release_tag }}
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -28,10 +46,26 @@ jobs:
       with:
         enable-cache: true
 
-    - name: Verify version matches tag
-      if: github.event_name == 'release'
+    - name: Resolve release tag
+      id: release_tag
+      shell: bash
       run: |
-        TAG_VERSION=${GITHUB_REF#refs/tags/v}
+        if [ "${{ github.event_name }}" = "release" ]; then
+          TAG="${{ github.event.release.tag_name }}"
+        else
+          TAG="${{ inputs.release_tag }}"
+        fi
+        if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+          echo "Error: expected a SemVer-style tag starting with v, got: $TAG"
+          exit 1
+        fi
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+    - name: Verify version matches release tag
+      shell: bash
+      run: |
+        TAG="${{ steps.release_tag.outputs.tag }}"
+        TAG_VERSION=${TAG#v}
         PACKAGE_VERSION=$(grep '^version = ' pyproject.toml | cut -d'"' -f2)
         if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
           echo "Error: Tag version ($TAG_VERSION) does not match package version ($PACKAGE_VERSION)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: release-please-main
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write
@@ -25,28 +29,3 @@ jobs:
           # Use PAT if GITHUB_TOKEN doesn't have PR creation permission
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: python
-
-      # Build and publish to PyPI when a release is created
-      - name: Checkout code
-        if: ${{ steps.release.outputs.release_created }}
-        uses: actions/checkout@v6
-
-      - name: Set up Python
-        if: ${{ steps.release.outputs.release_created }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install uv
-        if: ${{ steps.release.outputs.release_created }}
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-
-      - name: Build package
-        if: ${{ steps.release.outputs.release_created }}
-        run: uv build
-
-      - name: Publish to PyPI
-        if: ${{ steps.release.outputs.release_created && false }}  # Disabled by default
-        run: uv publish --token ${{ secrets.PYPI_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,8 @@ just check
 - Update README.md if adding user-facing features
 - Add docstrings to all public functions and classes
 - Include examples for new features in `examples/` directory
-- Update CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/)
+- Do not manually bump package versions in `pyproject.toml` or `ondine/__init__.py`
+- Do not manually add release entries unless a maintainer asks; release notes are managed through Release Please
 
 ### Commits
 
@@ -190,7 +191,7 @@ See `examples/15_custom_llm_provider.py` and `examples/16_custom_pipeline_stage.
    - Ensure all tests pass: `just test`
    - Run code quality checks: `just check`
    - Update documentation if needed
-   - Add entry to CHANGELOG.md
+   - Use a Conventional Commit style PR title if possible (`feat:`, `fix:`, `docs:`, etc.)
 
 2. **Submit PR:**
    - Write a clear title and description
@@ -200,7 +201,17 @@ See `examples/15_custom_llm_provider.py` and `examples/16_custom_pipeline_stage.
 
 3. **After approval:**
    - Maintainers will merge your PR
-   - Your contribution will be included in the next release!
+   - Release Please will prepare the next release from merged changes on `main`
+
+## Release Process
+
+Ondine uses GitHub Actions plus Release Please for releases:
+
+1. PRs merge into `main`
+2. `Release Please` updates or opens the release PR
+3. Publishing a GitHub release triggers the PyPI publish workflow
+
+Maintainers should avoid manual version bumps unless they are intentionally repairing release metadata.
 
 ## Good First Issues
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -104,7 +104,8 @@ just check
 - Update README.md if adding user-facing features
 - Add docstrings to all public functions and classes
 - Include examples for new features in `examples/` directory
-- Update CHANGELOG.md following [Keep a Changelog](https://keepachangelog.com/)
+- Do not manually bump package versions in `pyproject.toml` or `ondine/__init__.py`
+- Do not manually add release entries unless a maintainer asks; release notes are managed through Release Please
 
 ### Commits
 
@@ -190,7 +191,7 @@ See `examples/15_custom_llm_provider.py` and `examples/16_custom_pipeline_stage.
    - Ensure all tests pass: `just test`
    - Run code quality checks: `just check`
    - Update documentation if needed
-   - Add entry to CHANGELOG.md
+   - Use a Conventional Commit style PR title if possible (`feat:`, `fix:`, `docs:`, etc.)
 
 2. **Submit PR:**
    - Write a clear title and description
@@ -200,7 +201,17 @@ See `examples/15_custom_llm_provider.py` and `examples/16_custom_pipeline_stage.
 
 3. **After approval:**
    - Maintainers will merge your PR
-   - Your contribution will be included in the next release!
+   - Release Please will prepare the next release from merged changes on `main`
+
+## Release Process
+
+Ondine uses GitHub Actions plus Release Please for releases:
+
+1. PRs merge into `main`
+2. `Release Please` updates or opens the release PR
+3. Publishing a GitHub release triggers the PyPI publish workflow
+
+Maintainers should avoid manual version bumps unless they are intentionally repairing release metadata.
 
 ## Good First Issues
 


### PR DESCRIPTION
## Summary
- simplify the release workflow so `release.yml` only runs Release Please and no longer contains dead build/publish steps
- harden manual PyPI publishing by requiring an explicit release tag, checking out that tag, and validating the tag/version match before publish
- add workflow concurrency cancellation and update contributor docs to match the Release Please based release process

## Test plan
- [x] `uv run python -c \"import pathlib, yaml; [yaml.safe_load(pathlib.Path(p).read_text()) for p in ['.github/workflows/ci.yml','.github/workflows/release.yml','.github/workflows/publish-pypi.yml']]; print('workflow yaml ok')\"`
- [x] pre-commit hook suite passed locally, including unit tests (`570 passed, 6 skipped`)
- [ ] open/update a PR and confirm superseded CI runs are cancelled
- [ ] manually dispatch `Release to PyPI` with an invalid tag and confirm the workflow fails at tag validation
- [ ] manually dispatch `Release to PyPI` with a real release tag and confirm it checks out that tag and passes version validation before publish

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Implemented automated release workflow with concurrency controls to prevent duplicate runs and streamline the publishing process
  * Updated contribution guidelines to enforce conventional commit style (feat:, fix:, docs:, etc.) for automated changelog generation
  * Removed manual version bump requirements; release notes and versioning are now handled automatically

<!-- end of auto-generated comment: release notes by coderabbit.ai -->