### PR TITLE
fix: harden streaming, checkpoint, and router regressions

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -187,7 +187,7 @@
         "filename": "tests/unit/test_pipeline.py",
         "hashed_secret": "e91663304e62d5a4a65bc25e6f1b48a3c2769152",
         "is_verified": false,
-        "line_number": 99
+        "line_number": 110
       }
     ],
     "tests/unit/test_provider_presets.py": [
@@ -200,5 +200,5 @@
       }
     ]
   },
-  "generated_at": "2025-11-24T18:21:12Z"
+  "generated_at": "2026-03-08T00:05:45Z"
 }

--- a/ondine/adapters/checkpoint_storage.py
+++ b/ondine/adapters/checkpoint_storage.py
@@ -183,7 +183,15 @@ class LocalFileCheckpointStorage(CheckpointStorage):
                 # Try to load checkpoint for additional info
                 data = self.load(session_id)
                 rows_processed = data.get("last_processed_row", 0) if data else 0
-                stage = data.get("current_stage", "unknown") if data else "unknown"
+                stage = (
+                    str(
+                        data.get(
+                            "current_stage_index", data.get("current_stage", "unknown")
+                        )
+                    )
+                    if data
+                    else "unknown"
+                )
                 total_rows = data.get("total_rows", 0) if data else 0
                 cost_so_far = (
                     Decimal(str(data.get("accumulated_cost", 0)))

--- a/ondine/adapters/streaming_loader.py
+++ b/ondine/adapters/streaming_loader.py
@@ -6,6 +6,7 @@ lazy evaluation and streaming capabilities. Memory usage is O(chunk_size),
 not O(total_rows).
 """
 
+import json
 import logging
 from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
@@ -122,6 +123,17 @@ class StreamingDataLoader:
         Yields:
             Polars DataFrame chunks of size chunk_size
         """
+        suffix = self.path.suffix.lower()
+        if suffix == ".csv":
+            yield from self._iter_csv_chunks()
+            return
+        if suffix == ".parquet":
+            yield from self._iter_parquet_chunks()
+            return
+        if suffix in (".json", ".ndjson"):
+            yield from self._iter_ndjson_chunks()
+            return
+
         # Collect with streaming=True for memory efficiency
         # Then slice into chunks
         try:
@@ -141,6 +153,63 @@ class StreamingDataLoader:
             df = self._lazy_frame.collect()
             for i in range(0, len(df), self.chunk_size):
                 yield df.slice(i, self.chunk_size)
+
+    def _iter_csv_chunks(self) -> Iterator[pl.DataFrame]:
+        """Stream CSV chunks without materializing the full dataset."""
+        import pandas as pd
+
+        read_options = dict(self.read_options)
+        separator = read_options.pop("separator", None)
+        if separator is not None:
+            read_options["sep"] = separator
+        if self.columns is not None:
+            read_options["usecols"] = self.columns
+
+        for idx, chunk in enumerate(
+            pd.read_csv(self.path, chunksize=self.chunk_size, **read_options), start=1
+        ):
+            chunk_pl = pl.from_pandas(chunk)
+            logger.debug(
+                f"Yielding CSV chunk {idx}: {len(chunk_pl)} rows from {self.path.name}"
+            )
+            yield chunk_pl
+
+    def _iter_parquet_chunks(self) -> Iterator[pl.DataFrame]:
+        """Stream Parquet chunks via Arrow batches when available."""
+        import pyarrow.parquet as pq
+
+        parquet_file = pq.ParquetFile(self.path)
+        for idx, batch in enumerate(
+            parquet_file.iter_batches(
+                batch_size=self.chunk_size,
+                columns=self.columns,
+            ),
+            start=1,
+        ):
+            chunk = pl.from_arrow(batch)
+            logger.debug(
+                f"Yielding Parquet chunk {idx}: {len(chunk)} rows from {self.path.name}"
+            )
+            yield chunk
+
+    def _iter_ndjson_chunks(self) -> Iterator[pl.DataFrame]:
+        """Stream NDJSON chunks line-by-line without full materialization."""
+        rows: list[dict[str, Any]] = []
+        with self.path.open(encoding="utf-8") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                row = json.loads(stripped)
+                if self.columns is not None:
+                    row = {column: row.get(column) for column in self.columns}
+                rows.append(row)
+                if len(rows) >= self.chunk_size:
+                    yield pl.DataFrame(rows)
+                    rows = []
+
+        if rows:
+            yield pl.DataFrame(rows)
 
     async def stream_chunks(self) -> AsyncIterator[pl.DataFrame]:
         """

--- a/ondine/adapters/unified_litellm_client.py
+++ b/ondine/adapters/unified_litellm_client.py
@@ -335,6 +335,7 @@ class UnifiedLiteLLMClient(LLMClient):
             # Store resilience config for observability
             self._allowed_fails = config.get("allowed_fails", 3)
             self._cooldown_time = config.get("cooldown_time", 60)
+            self._wrap_router_failure_callbacks()
 
             # Display Router info using Rich utilities
             strategy = router_kwargs.get("routing_strategy", "simple-shuffle")
@@ -373,6 +374,39 @@ class UnifiedLiteLLMClient(LLMClient):
         except Exception as e:
             logger.error(f"Router init failed: {e}")
             self.router = None
+
+    def _wrap_router_failure_callbacks(self) -> None:
+        """Attach Ondine cooldown observability to LiteLLM Router failure hooks."""
+        if self.router is None:
+            return
+
+        original_failure_callback = getattr(
+            self.router, "deployment_callback_on_failure", None
+        )
+        if callable(original_failure_callback):
+
+            def wrapped_failure_callback(*args, **kwargs):
+                result = original_failure_callback(*args, **kwargs)
+                if result:
+                    callback_kwargs = args[0] if args else kwargs.get("kwargs", {})
+                    litellm_params = callback_kwargs.get("litellm_params", {}) or {}
+                    model_info = litellm_params.get("model_info", {}) or {}
+                    deployment = {
+                        "model_id": str(model_info.get("id"))
+                        if model_info.get("id") is not None
+                        else None,
+                        "model_name": callback_kwargs.get("model", self.model),
+                        "litellm_params": {
+                            "model": litellm_params.get("model", self.model)
+                        },
+                    }
+                    exception = callback_kwargs.get(
+                        "exception", Exception("Router deployment failure")
+                    )
+                    self._emit_cooldown_event(deployment, exception)
+                return result
+
+            self.router.deployment_callback_on_failure = wrapped_failure_callback
 
     def _emit_cooldown_event(
         self,

--- a/ondine/api/pipeline.py
+++ b/ondine/api/pipeline.py
@@ -23,7 +23,9 @@ from ondine.adapters.streaming_writer import StreamingResultWriter
 from ondine.core.models import (
     CostEstimate,
     ExecutionResult,
-    ProcessingStats,
+    LLMResponse,
+    ResponseBatch,
+    RowMetadata,
     ValidationResult,
 )
 from ondine.core.specifications import (
@@ -290,6 +292,9 @@ class Pipeline:
             # Create new context
             context = ExecutionContext(pipeline_id=self.id)
 
+        context.intermediate_data.setdefault("completed_responses", [])
+        context.intermediate_data["resumed_from_checkpoint"] = bool(resume_from)
+
         # Add default observers if none specified
         if not self.observers:
             self.observers = [
@@ -486,6 +491,7 @@ class Pipeline:
     ) -> pd.DataFrame:
         """Execute stages with progress tracking enabled."""
         specs = self.specifications
+        resume_mode = bool(context.intermediate_data.get("resumed_from_checkpoint"))
 
         # Create budget controller if max_budget specified
         budget_controller = None
@@ -503,14 +509,15 @@ class Pipeline:
         loader = DataLoaderStage(self.dataframe)
         df = self._execute_stage(loader, specs.dataset, context)
         context.intermediate_data["loaded_data"] = df
+        working_df = df
 
         # Optional: Preprocess loaded data
         if specs.processing.enable_preprocessing:
             from ondine.utils.input_preprocessing import preprocess_container
 
             self.logger.info("Preprocessing loaded data...")
-            df, stats = preprocess_container(
-                df,
+            working_df, stats = preprocess_container(
+                working_df,
                 input_columns=specs.dataset.input_columns,
                 max_length=specs.processing.preprocessing_max_length,
             )
@@ -520,13 +527,22 @@ class Pipeline:
                 f"{stats.truncated_count} truncated"
             )
             # Store preprocessed data for retry
-            context.intermediate_data["preprocessed_data"] = df
+            context.intermediate_data["preprocessed_data"] = working_df
+
+        if resume_mode:
+            working_df = self._filter_container_for_resume(
+                working_df, context.last_processed_row
+            )
+            self.logger.info(
+                f"Resume mode: skipping first {context.last_processed_row + 1} rows, "
+                f"processing {len(working_df)} remaining rows"
+            )
 
         # Stage 2: Format prompts
         formatter = PromptFormatterStage(
             specs.processing.batch_size, use_jinja2=specs.processing.use_jinja2
         )
-        batches = self._execute_stage(formatter, (df, specs.prompt), context)
+        batches = self._execute_stage(formatter, (working_df, specs.prompt), context)
         context.intermediate_data["prompt_batches"] = batches
 
         # Stage 2.5: Aggregate into batch prompts (if batch_size > 1)
@@ -594,14 +610,14 @@ class Pipeline:
             output_cls=specs.metadata.get("structured_output_model")
             if specs.metadata
             else None,
+            budget_controller=budget_controller,
         )
         # Stage 3: Execute LLM invocation
-        response_batches = self._execute_stage(llm_stage, batches, context)
+        response_batches = (
+            self._execute_stage(llm_stage, batches, context) if batches else []
+        )
         context.intermediate_data["response_batches"] = response_batches
-
-        # Check budget after LLM invocation
-        if budget_controller:
-            budget_controller.check_budget(context.accumulated_cost)
+        response_batches = self._restore_completed_response_batches(context)
 
         # Save checkpoint after expensive LLM stage
         if state_manager.should_checkpoint(context.last_processed_row):
@@ -681,6 +697,61 @@ class Pipeline:
 
         return ResultContainerImpl(data=merged_rows, columns=merged_columns)
 
+    def _filter_container_for_resume(
+        self, container: Any, last_processed_row: int
+    ) -> Any:
+        """Return only rows that still need processing, preserving original indices."""
+        from ondine.adapters.containers import DictListContainer
+
+        filtered_rows = []
+        for idx, row in enumerate(container):
+            if idx <= last_processed_row:
+                continue
+            resumed_row = dict(row)
+            resumed_row["_index"] = idx
+            filtered_rows.append(resumed_row)
+
+        columns = list(container.columns)
+        if "_index" not in columns:
+            columns.append("_index")
+        return DictListContainer(data=filtered_rows, columns=columns)
+
+    def _restore_completed_response_batches(
+        self, context: ExecutionContext
+    ) -> list[ResponseBatch]:
+        """Rebuild response batches from checkpoint-safe completed response records."""
+        restored_batches: list[ResponseBatch] = []
+        for idx, record in enumerate(
+            context.intermediate_data.get("completed_responses", [])
+        ):
+            row_metadata = record.get("row_metadata", {})
+            response = LLMResponse(
+                text=record.get("text", ""),
+                tokens_in=record.get("tokens_in", 0),
+                tokens_out=record.get("tokens_out", 0),
+                model=record.get("model", self.specifications.llm.model),
+                cost=Decimal(str(record.get("cost", "0"))),
+                latency_ms=record.get("latency_ms", 0.0),
+                metadata=record.get("metadata", {}) or {},
+            )
+            metadata = RowMetadata(
+                row_index=row_metadata.get("row_index", idx),
+                row_id=row_metadata.get("row_id"),
+                custom=row_metadata.get("custom", {}) or {},
+            )
+            restored_batches.append(
+                ResponseBatch(
+                    responses=[response],
+                    metadata=[metadata],
+                    tokens_used=response.tokens_in + response.tokens_out,
+                    cost=response.cost,
+                    batch_id=idx,
+                    latencies_ms=[response.latency_ms],
+                )
+            )
+
+        return restored_batches
+
     async def execute_async(self, resume_from: UUID | None = None) -> ExecutionResult:
         """
         Execute pipeline asynchronously.
@@ -740,51 +811,68 @@ class Pipeline:
         elif chunk_size is None:
             chunk_size = 1000  # Default fallback
 
-        # For now, execute the full pipeline and split result into chunks
-        # TODO: Implement proper streaming execution that processes chunks independently
-        result = self.execute()
+        streaming_config = {}
+        if isinstance(self.specifications.metadata, dict):
+            streaming_config = self.specifications.metadata.get("streaming", {}) or {}
+        max_pending_chunks = streaming_config.get("max_pending_chunks", 3)
 
-        # Split the result data into chunks and yield as separate ExecutionResults
-        total_rows = len(result.data)
-        for start_idx in range(0, total_rows, chunk_size):
-            end_idx = min(start_idx + chunk_size, total_rows)
-            chunk_data = result.data.iloc[start_idx:end_idx].copy()
+        import asyncio
+        import queue
+        import threading
 
-            # Create a chunk result with proportional metrics
-            chunk_rows = len(chunk_data)
-            chunk_result = ExecutionResult(
-                data=chunk_data,
-                metrics=ProcessingStats(
-                    total_rows=chunk_rows,
-                    processed_rows=chunk_rows,
-                    failed_rows=0,
-                    skipped_rows=0,
-                    rows_per_second=result.metrics.rows_per_second,
-                    total_duration_seconds=result.metrics.total_duration_seconds
-                    * (chunk_rows / total_rows),
-                    stage_durations=result.metrics.stage_durations,
-                ),
-                costs=CostEstimate(
-                    total_cost=result.costs.total_cost
-                    * Decimal(chunk_rows / total_rows),
-                    total_tokens=int(
-                        result.costs.total_tokens * (chunk_rows / total_rows)
-                    ),
-                    input_tokens=int(
-                        result.costs.input_tokens * (chunk_rows / total_rows)
-                    ),
-                    output_tokens=int(
-                        result.costs.output_tokens * (chunk_rows / total_rows)
-                    ),
-                    rows=chunk_rows,
-                    confidence=result.costs.confidence,
-                ),
-                execution_id=result.execution_id,
-                start_time=result.start_time,
-                end_time=result.end_time,
-                success=True,
-            )
-            yield chunk_result
+        result_queue: queue.Queue[tuple[str, ExecutionResult | Exception | None]] = (
+            queue.Queue(maxsize=max_pending_chunks)
+        )
+        stop_requested = threading.Event()
+
+        def publish(kind: str, payload: ExecutionResult | Exception | None) -> None:
+            while True:
+                if stop_requested.is_set():
+                    return
+                try:
+                    result_queue.put((kind, payload), timeout=0.1)
+                    return
+                except queue.Full:
+                    continue
+
+        def runner() -> None:
+            async def stream_results() -> None:
+                try:
+                    async for chunk_result in self.execute_stream_async(
+                        chunk_size=chunk_size,
+                        max_pending_chunks=max_pending_chunks,
+                    ):
+                        if stop_requested.is_set():
+                            break
+                        publish("item", chunk_result)
+                    publish("done", None)
+                except Exception as exc:
+                    publish("error", exc)
+
+            loop = asyncio.new_event_loop()
+            try:
+                asyncio.set_event_loop(loop)
+                loop.run_until_complete(stream_results())
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            finally:
+                asyncio.set_event_loop(None)
+                loop.close()
+
+        thread = threading.Thread(target=runner, daemon=True)
+        thread.start()
+
+        try:
+            while True:
+                kind, payload = result_queue.get()
+                if kind == "item":
+                    yield payload  # type: ignore[misc]
+                elif kind == "error":
+                    raise payload  # type: ignore[misc]
+                else:
+                    break
+        finally:
+            stop_requested.set()
+            thread.join(timeout=1)
 
     async def execute_stream_async(
         self,
@@ -827,6 +915,14 @@ class Pipeline:
         # Setup streaming components
         specs = self.specifications
         source_path = specs.dataset.source_path
+        budget_controller = None
+        if specs.processing.max_budget:
+            from ondine.utils.budget_controller import BudgetController
+
+            budget_controller = BudgetController(
+                max_budget=specs.processing.max_budget,
+                fail_on_exceed=True,
+            )
 
         if source_path is None and self.dataframe is None:
             raise ValueError(
@@ -848,6 +944,9 @@ class Pipeline:
         total_tokens = 0
         chunk_index = 0
 
+        producer_task = None
+        producer_error = None
+
         try:
             # Create data source
             if source_path:
@@ -861,8 +960,28 @@ class Pipeline:
                 # Stream from in-memory dataframe
                 data_source = self._stream_dataframe_chunks(self.dataframe, chunk_size)
 
+            queue: asyncio.Queue[pl.DataFrame | None] = asyncio.Queue(
+                maxsize=max_pending_chunks
+            )
+
+            async def producer() -> None:
+                nonlocal producer_error
+                try:
+                    async for chunk_pl in data_source:
+                        await queue.put(chunk_pl)
+                except Exception as exc:
+                    producer_error = exc
+                finally:
+                    await queue.put(None)
+
+            producer_task = asyncio.create_task(producer())
+
             # Process each chunk through the pipeline
-            async for chunk_pl in data_source:
+            while True:
+                chunk_pl = await queue.get()
+                if chunk_pl is None:
+                    break
+
                 # Convert Polars to Pandas for compatibility with existing stages
                 chunk_df = chunk_pl.to_pandas()
 
@@ -878,16 +997,30 @@ class Pipeline:
 
                 # Write incrementally if writer configured
                 if writer and chunk_result.data is not None:
-                    result_pl = pl.from_pandas(chunk_result.data)
+                    result_pl = chunk_result.to_polars()
                     await writer.append_async(result_pl)
 
                 chunk_index += 1
                 yield chunk_result
 
+                # Enforce streaming budgets across chunk boundaries using cumulative cost.
+                if budget_controller is not None:
+                    budget_controller.check_budget(total_cost)
+
                 # Yield control to event loop
                 await asyncio.sleep(0)
 
+            if producer_error is not None:
+                raise producer_error
+
         finally:
+            if producer_task and not producer_task.done():
+                producer_task.cancel()
+                try:
+                    await producer_task
+                except asyncio.CancelledError:
+                    pass
+
             # Finalize writer
             if writer:
                 write_stats = writer.finalize()

--- a/ondine/cli/main.py
+++ b/ondine/cli/main.py
@@ -78,6 +78,40 @@ PROVIDER_METADATA = {
     },
 }
 
+
+def _load_specs_from_config(config: Path):
+    """Load pipeline specifications from YAML or JSON."""
+    suffix = config.suffix.lower()
+    if suffix == ".json":
+        return ConfigLoader.from_json(str(config))
+    return ConfigLoader.from_yaml(str(config))
+
+
+def _apply_output_override(specs, output: Path) -> None:
+    """Apply CLI output override to pipeline specifications."""
+    if specs.output:
+        specs.output.destination_path = output
+        return
+
+    from ondine.core.specifications import MergeStrategy, OutputSpec
+
+    output_suffix = output.suffix.lower()
+    if output_suffix == ".csv":
+        output_type = DataSourceType.CSV
+    elif output_suffix in [".xlsx", ".xls"]:
+        output_type = DataSourceType.EXCEL
+    elif output_suffix == ".parquet":
+        output_type = DataSourceType.PARQUET
+    else:
+        output_type = DataSourceType.CSV
+
+    specs.output = OutputSpec(
+        destination_type=output_type,
+        destination_path=output,
+        merge_strategy=MergeStrategy.REPLACE,
+    )
+
+
 # Validate metadata completeness at module load
 assert set(LLMProvider) == set(PROVIDER_METADATA.keys()), (
     "PROVIDER_METADATA must include all LLMProvider values"
@@ -260,7 +294,7 @@ def process(
     try:
         # Load configuration
         console.print(f"[cyan]Loading configuration from {config}...[/cyan]")
-        specs = ConfigLoader.from_yaml(str(config))
+        specs = _load_specs_from_config(config)
 
         # Override with CLI arguments (if provided)
         if input:
@@ -268,28 +302,7 @@ def process(
 
         # Set output configuration (if provided)
         if output:
-            if specs.output:
-                specs.output.destination_path = output
-            else:
-                # Create output spec if not in config
-                from ondine.core.specifications import MergeStrategy, OutputSpec
-
-                # Detect output type from extension
-                output_suffix = output.suffix.lower()
-                if output_suffix == ".csv":
-                    output_type = DataSourceType.CSV
-                elif output_suffix in [".xlsx", ".xls"]:
-                    output_type = DataSourceType.EXCEL
-                elif output_suffix == ".parquet":
-                    output_type = DataSourceType.PARQUET
-                else:
-                    output_type = DataSourceType.CSV  # Default
-
-                specs.output = OutputSpec(
-                    destination_type=output_type,
-                    destination_path=output,
-                    merge_strategy=MergeStrategy.REPLACE,
-                )
+            _apply_output_override(specs, output)
 
         if provider:
             specs.llm.provider = LLMProvider(provider)
@@ -486,7 +499,7 @@ def estimate(
     try:
         # Load configuration
         console.print(f"[cyan]Loading configuration from {config}...[/cyan]")
-        specs = ConfigLoader.from_yaml(str(config))
+        specs = _load_specs_from_config(config)
 
         # Override
         specs.dataset.source_path = input
@@ -552,9 +565,9 @@ def estimate(
 )
 @click.option(
     "--checkpoint-dir",
-    type=click.Path(exists=True, path_type=Path),
-    default=".checkpoints",
-    help="Checkpoint directory (default: .checkpoints)",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Checkpoint directory (defaults to config value or .checkpoints)",
 )
 @click.option(
     "--output",
@@ -562,10 +575,33 @@ def estimate(
     type=click.Path(path_type=Path),
     help="Override output path",
 )
+@click.option(
+    "--config",
+    "-c",
+    required=False,
+    type=click.Path(exists=True, path_type=Path),
+    help="Original YAML/JSON configuration file used for the run",
+)
+@click.option(
+    "--input",
+    "-i",
+    required=False,
+    type=click.Path(exists=True, path_type=Path),
+    help="Override input data source from config",
+)
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Show traceback on resume errors",
+)
 def resume(
     session_id: str,
-    checkpoint_dir: Path,
+    checkpoint_dir: Path | None,
     output: Path | None,
+    config: Path | None,
+    input: Path | None,
+    verbose: bool,
 ):
     """
     Resume pipeline execution from checkpoint.
@@ -584,38 +620,72 @@ def resume(
         from ondine.adapters import LocalFileCheckpointStorage
         from ondine.orchestration import StateManager
 
-        # Load checkpoint
-        console.print(f"[cyan]Looking for checkpoint in {checkpoint_dir}...[/cyan]")
-
-        storage = LocalFileCheckpointStorage(str(checkpoint_dir))
-        state_manager = StateManager(storage)
-
         session_uuid = UUID(session_id)
+        specs = _load_specs_from_config(config) if config is not None else None
+        effective_checkpoint_dir = checkpoint_dir or (
+            specs.processing.checkpoint_dir
+            if specs is not None
+            else Path(".checkpoints")
+        )
+
+        console.print(
+            f"[cyan]Looking for checkpoint in {effective_checkpoint_dir}...[/cyan]"
+        )
+
+        storage = LocalFileCheckpointStorage(effective_checkpoint_dir)
+        state_manager = StateManager(storage)
 
         if not state_manager.can_resume(session_uuid):
             console.print(f"[red]❌ No checkpoint found for session {session_id}[/red]")
             console.print(
-                f"[yellow]Check checkpoint directory: {checkpoint_dir}[/yellow]"
+                f"[yellow]Check checkpoint directory: {effective_checkpoint_dir}[/yellow]"
             )
             sys.exit(1)
 
-        # Load checkpoint
-        checkpoint_info = state_manager.get_latest_checkpoint(session_uuid)
+        checkpoint_info = next(
+            (
+                cp
+                for cp in state_manager.list_checkpoints()
+                if cp.session_id == session_uuid
+            ),
+            None,
+        )
+        if checkpoint_info is None:
+            console.print(
+                f"[red]❌ Checkpoint exists but metadata could not be loaded for {session_id}[/red]"
+            )
+            sys.exit(1)
+
         console.print(
-            f"[green]Found checkpoint at row {checkpoint_info.row_index}[/green]"
+            f"[green]Found checkpoint at row {checkpoint_info.rows_processed}[/green]"
         )
 
-        # Resume execution
+        if config is None:
+            console.print(
+                "[red]❌ Resume requires the original pipeline config via --config[/red]"
+            )
+            sys.exit(1)
+
+        console.print(f"[cyan]Loading configuration from {config}...[/cyan]")
+        specs.processing.checkpoint_dir = effective_checkpoint_dir
+
+        if input is not None:
+            specs.dataset.source_path = input
+
+        if output is not None:
+            _apply_output_override(specs, output)
+
+        console.print("[cyan]Creating pipeline...[/cyan]")
+        pipeline = Pipeline(specs)
+        validation = pipeline.validate()
+        if not validation.is_valid:
+            console.print("[red]❌ Validation failed:[/red]")
+            for error in validation.errors:
+                console.print(f"  [red]• {error}[/red]")
+            sys.exit(1)
+
         console.print("[cyan]Resuming execution...[/cyan]")
-
-        # Note: Full resume implementation would load the original pipeline
-        # and continue from checkpoint. For now, we show the checkpoint info.
-        console.print(
-            "\n[yellow]Full resume functionality requires the original pipeline configuration[/yellow]"
-        )
-        console.print(
-            "[yellow]Please use Pipeline.execute(resume_from=session_id) in Python code[/yellow]"
-        )
+        result = pipeline.execute(resume_from=session_uuid)
 
         # Display checkpoint info
         table = Table(title="Checkpoint Information")
@@ -623,13 +693,31 @@ def resume(
         table.add_column("Value", style="green")
 
         table.add_row("Session ID", str(checkpoint_info.session_id))
-        table.add_row("Checkpoint Path", checkpoint_info.checkpoint_path)
-        table.add_row("Last Row", str(checkpoint_info.row_index))
-        table.add_row("Last Stage", str(checkpoint_info.stage_index))
+        table.add_row("Checkpoint Path", checkpoint_info.path or "unknown")
+        table.add_row("Rows Processed", str(checkpoint_info.rows_processed))
+        table.add_row("Total Rows", str(checkpoint_info.total_rows))
+        table.add_row("Last Stage", str(checkpoint_info.stage))
         table.add_row("Timestamp", str(checkpoint_info.timestamp))
-        table.add_row("Size", f"{checkpoint_info.size_bytes:,} bytes")
+        table.add_row("Cost So Far", f"${checkpoint_info.cost_so_far}")
 
         console.print(table)
+        console.print("\n[green]Resume complete![/green]")
+
+        results_table = Table(title="Execution Results")
+        results_table.add_column("Metric", style="cyan")
+        results_table.add_column("Value", style="green")
+        results_table.add_row("Total Rows", str(result.metrics.total_rows))
+        results_table.add_row("Processed", str(result.metrics.processed_rows))
+        results_table.add_row("Failed", str(result.metrics.failed_rows))
+        results_table.add_row("Skipped", str(result.metrics.skipped_rows))
+        results_table.add_row("Duration", f"{result.duration:.2f}s")
+        results_table.add_row("Total Cost", f"${result.costs.total_cost}")
+        console.print(results_table)
+
+        if specs.output and specs.output.destination_path:
+            console.print(
+                f"\n[green]Output written to: {specs.output.destination_path}[/green]"
+            )
 
     except ValueError:
         console.print(f"[red]❌ Invalid session ID format: {session_id}[/red]")
@@ -639,6 +727,8 @@ def resume(
         sys.exit(1)
     except Exception as e:
         console.print(f"[red]❌ Error: {e}[/red]")
+        if verbose:
+            console.print_exception()
         sys.exit(1)
 
 
@@ -674,7 +764,7 @@ def validate(config: Path, verbose: bool):
     try:
         # Load configuration
         console.print(f"[cyan]Loading configuration from {config}...[/cyan]")
-        specs = ConfigLoader.from_yaml(str(config))
+        specs = _load_specs_from_config(config)
 
         console.print("[green]Configuration loaded successfully[/green]")
 
@@ -764,18 +854,22 @@ def list_checkpoints(checkpoint_dir: Path):
         # Display checkpoints
         table = Table(title=f"Checkpoints in {checkpoint_dir}")
         table.add_column("Session ID", style="cyan")
-        table.add_column("Row", style="green")
+        table.add_column("Rows", style="green")
+        table.add_column("Total", style="green")
         table.add_column("Stage", style="green")
+        table.add_column("Cost", style="magenta")
         table.add_column("Timestamp", style="yellow")
-        table.add_column("Size", style="magenta")
+        table.add_column("Path", style="white")
 
         for cp in checkpoints:
             table.add_row(
                 str(cp.session_id)[:8] + "...",
-                str(cp.row_index),
-                str(cp.stage_index),
+                str(cp.rows_processed),
+                str(cp.total_rows),
+                str(cp.stage),
+                f"${cp.cost_so_far}",
                 cp.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
-                f"{cp.size_bytes:,} bytes",
+                cp.path or "unknown",
             )
 
         console.print("\n")

--- a/ondine/stages/llm_invocation_stage.py
+++ b/ondine/stages/llm_invocation_stage.py
@@ -32,6 +32,7 @@ from ondine.utils import (
     RateLimitError,
     RetryHandler,
 )
+from ondine.utils.budget_controller import BudgetExceededError
 
 
 class LLMInvocationStage(PipelineStage[list[PromptBatch], list[ResponseBatch]]):
@@ -60,6 +61,7 @@ class LLMInvocationStage(PipelineStage[list[PromptBatch], list[ResponseBatch]]):
         error_policy: ErrorPolicy = ErrorPolicy.SKIP,
         max_retries: int = 3,
         output_cls: type[BaseModel] | None = None,
+        budget_controller: Any | None = None,
     ):
         """
         Initialize LLM invocation stage.
@@ -72,6 +74,7 @@ class LLMInvocationStage(PipelineStage[list[PromptBatch], list[ResponseBatch]]):
             error_policy: Policy for handling errors
             max_retries: Maximum retry attempts
             output_cls: Optional Pydantic model for structured output
+            budget_controller: Optional budget controller for mid-run enforcement
         """
         super().__init__("LLMInvocation")
         self.llm_client = llm_client
@@ -79,6 +82,7 @@ class LLMInvocationStage(PipelineStage[list[PromptBatch], list[ResponseBatch]]):
         self.rate_limiter = rate_limiter
         self.retry_handler = retry_handler or RetryHandler()
         self.output_cls = output_cls
+        self.budget_controller = budget_controller
         self.error_handler = ErrorHandler(
             policy=error_policy,
             max_retries=max_retries,
@@ -108,7 +112,11 @@ class LLMInvocationStage(PipelineStage[list[PromptBatch], list[ResponseBatch]]):
         # Execute async processing
         try:
             return asyncio.run(self._process_async(batches, context))
-        except RuntimeError:
+        except RuntimeError as exc:
+            if "asyncio.run() cannot be called from a running event loop" not in str(
+                exc
+            ):
+                raise
             # Loop already running (e.g. Jupyter)
             import nest_asyncio
 
@@ -181,13 +189,45 @@ class LLMInvocationStage(PipelineStage[list[PromptBatch], list[ResponseBatch]]):
             async with semaphore:
                 return await self._process_single_item(idx, item, context)
 
-        tasks = [_process_one(idx, item) for idx, item in enumerate(items)]
-        responses = await asyncio.gather(*tasks)
+        if self.concurrency <= 1:
+            responses = []
+            for idx, item in enumerate(items):
+                responses.append(await _process_one(idx, item))
+
+            self._log_distribution_summary()
+            return responses
+
+        task_map = {
+            asyncio.create_task(_process_one(idx, item)): idx
+            for idx, item in enumerate(items)
+        }
+        pending = set(task_map)
+        responses: list[LLMResponse | None] = [None] * len(items)
+
+        while pending:
+            done, pending = await asyncio.wait(
+                pending, return_when=asyncio.FIRST_EXCEPTION
+            )
+
+            first_error = None
+            for task in done:
+                idx = task_map[task]
+                exc = task.exception()
+                if exc is not None and first_error is None:
+                    first_error = exc
+                    continue
+                responses[idx] = task.result()
+
+            if first_error is not None:
+                for task in pending:
+                    task.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+                raise first_error
 
         # Log distribution summary
         self._log_distribution_summary()
 
-        return list(responses)
+        return [response for response in responses if response is not None]
 
     async def _process_single_item(self, idx: int, item, context: Any) -> LLMResponse:
         """Process a single prompt item with error handling."""
@@ -215,8 +255,18 @@ class LLMInvocationStage(PipelineStage[list[PromptBatch], list[ResponseBatch]]):
 
             return response
 
+        except BudgetExceededError:
+            raise
         except Exception as e:
-            return self._handle_error(e, idx, self._total_rows)
+            response = self._handle_error(e, idx, self._total_rows)
+
+            batch_size = BatchProcessor.get_batch_size(item.metadata)
+            self._progress_reporter.update(
+                rows_completed=batch_size, cost=response.cost
+            )
+            self._update_context(context, idx, item.metadata, response)
+
+            return response
 
     def _invoke_with_retry_and_ratelimit(
         self,
@@ -309,6 +359,31 @@ class LLMInvocationStage(PipelineStage[list[PromptBatch], list[ResponseBatch]]):
             context.intermediate_data["token_tracking"]["output_tokens"] += (
                 response.tokens_out
             )
+
+            # Persist completed responses incrementally so checkpoints can resume
+            # without redoing already finished LLM calls.
+            completed_responses = context.intermediate_data.setdefault(
+                "completed_responses", []
+            )
+            completed_responses.append(
+                {
+                    "text": response.text,
+                    "tokens_in": response.tokens_in,
+                    "tokens_out": response.tokens_out,
+                    "model": response.model,
+                    "cost": str(response.cost),
+                    "latency_ms": response.latency_ms,
+                    "metadata": response.metadata or {},
+                    "row_metadata": {
+                        "row_index": metadata.row_index,
+                        "row_id": metadata.row_id,
+                        "custom": metadata.custom or {},
+                    },
+                }
+            )
+
+            if self.budget_controller:
+                self.budget_controller.check_budget(context.accumulated_cost)
 
     def _handle_error(self, error: Exception, idx: int, total: int) -> LLMResponse:
         """Handle processing error according to error policy."""

--- a/tests/integration/test_budget_enforcement_e2e.py
+++ b/tests/integration/test_budget_enforcement_e2e.py
@@ -1,108 +1,120 @@
-"""
-E2E test for budget enforcement.
+"""Integration tests for budget enforcement behavior."""
 
-Validates that BudgetController correctly stops pipeline execution
-when cost limits are exceeded, preventing runaway expenses.
-"""
-
-import os
 from decimal import Decimal
+from tempfile import TemporaryDirectory
+from unittest.mock import AsyncMock, Mock, patch
 
 import pandas as pd
 import pytest
 
 from ondine import PipelineBuilder
+from ondine.core.models import LLMResponse
+from ondine.utils.budget_controller import BudgetExceededError
+
+
+def _row_from_prompt(prompt: str) -> int:
+    for i in range(10):
+        if f"Item {i}" in prompt:
+            return i
+    raise AssertionError(f"Unknown prompt: {prompt}")
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize(
-    ("provider", "model", "api_key_env"),
-    [
-        ("openai", "gpt-4o-mini", "OPENAI_API_KEY"),
-    ],
-)
-def test_budget_enforcement_stops_execution(provider, model, api_key_env):
+@patch("ondine.adapters.provider_registry.ProviderRegistry.get")
+def test_budget_enforcement_stops_mid_run(mock_get):
     """
-    Test that pipeline stops when budget limit is exceeded.
-
-    This is a critical financial safety feature.
+    Regression this catches:
+    the pipeline must stop as soon as accumulated cost crosses the budget,
+    not after finishing the whole dataset.
     """
-    api_key = os.getenv(api_key_env)
-    if not api_key:
-        pytest.skip(f"{api_key_env} not set")
+    df = pd.DataFrame({"text": [f"Item {i}" for i in range(5)]})
+    processed_rows: list[int] = []
 
-    # Create large dataset that would exceed budget
-    df = pd.DataFrame({"text": [f"Long text {i} " * 50 for i in range(100)]})
+    async def mock_invoke(prompt, **kwargs):
+        row_num = _row_from_prompt(prompt)
+        processed_rows.append(row_num)
+        return LLMResponse(
+            text=f"summary_{row_num}",
+            tokens_in=10,
+            tokens_out=10,
+            model="test-model",
+            cost=Decimal("0.40"),
+            latency_ms=5.0,
+        )
 
-    # Set very low budget (should stop after a few rows)
+    mock_client = Mock()
+    mock_client.ainvoke = AsyncMock(side_effect=mock_invoke)
+    mock_client.start = AsyncMock()
+    mock_client.stop = AsyncMock()
+    mock_client.router = None
+    mock_client.model = "test-model"
+    mock_client.spec = Mock(model="test-model")
+    mock_get.return_value = Mock(return_value=mock_client)
+
+    with TemporaryDirectory() as tmpdir:
+        pipeline = (
+            PipelineBuilder.create()
+            .from_dataframe(df, input_columns=["text"], output_columns=["summary"])
+            .with_prompt("Summarize: {text}")
+            .with_llm(provider="openai", model="test-model", temperature=0.0)
+            .with_processing_batch_size(1)
+            .with_concurrency(1)
+            .with_max_budget(0.75)
+            .with_checkpoint_dir(tmpdir)
+            .build()
+        )
+
+        with pytest.raises(BudgetExceededError, match="Budget exceeded"):
+            pipeline.execute()
+
+        assert processed_rows == [0, 1]
+
+
+@pytest.mark.integration
+@patch("ondine.utils.budget_controller.logger.warning")
+@patch("ondine.adapters.provider_registry.ProviderRegistry.get")
+def test_budget_warning_threshold_emits_warning(mock_get, mock_warning):
+    """
+    Regression this catches:
+    warning thresholds must be emitted before the hard budget limit is reached.
+    """
+    df = pd.DataFrame({"text": [f"Item {i}" for i in range(3)]})
+
+    async def mock_invoke(prompt, **kwargs):
+        row_num = _row_from_prompt(prompt)
+        return LLMResponse(
+            text=f"summary_{row_num}",
+            tokens_in=10,
+            tokens_out=10,
+            model="test-model",
+            cost=Decimal("0.16"),
+            latency_ms=5.0,
+        )
+
+    mock_client = Mock()
+    mock_client.ainvoke = AsyncMock(side_effect=mock_invoke)
+    mock_client.start = AsyncMock()
+    mock_client.stop = AsyncMock()
+    mock_client.router = None
+    mock_client.model = "test-model"
+    mock_client.spec = Mock(model="test-model")
+    mock_get.return_value = Mock(return_value=mock_client)
+
     pipeline = (
         PipelineBuilder.create()
         .from_dataframe(df, input_columns=["text"], output_columns=["summary"])
-        .with_prompt("Summarize: {{text}}")
-        .with_llm(
-            provider=provider,
-            model=model,
-            api_key=api_key,
-            temperature=0.0,
-            input_cost_per_1k_tokens=Decimal("0.00015"),  # gpt-4o-mini pricing
-            output_cost_per_1k_tokens=Decimal("0.0006"),
-        )
-        .with_batch_size(100)
-        .with_processing_batch_size(10)  # 10 API calls total
-        .with_max_budget(0.001)  # Very low budget ($0.001 = 1 cent)
-        .build()
-    )
-
-    # Execute (should raise BudgetExceededError)
-    from ondine.utils.budget_controller import BudgetExceededError
-
-    with pytest.raises(BudgetExceededError) as exc_info:
-        pipeline.execute()
-
-    # Verify budget was exceeded
-    assert "Budget exceeded" in str(exc_info.value)
-    assert "$0.001" in str(exc_info.value) or "$0.00" in str(exc_info.value)
-
-    print(f"\n{provider.upper()} Budget Enforcement Results:")
-    print("  Budget: $0.001")
-    print(f"  Error: {exc_info.value}")
-    print("  ✅ Budget enforcement working correctly (raised exception)")
-
-
-@pytest.mark.integration
-def test_budget_warning_threshold():
-    """
-    Test that budget warnings are logged at threshold.
-
-    Validates the warning system alerts users before hitting hard limit.
-    """
-    api_key = os.getenv("GROQ_API_KEY")
-    if not api_key:
-        pytest.skip("GROQ_API_KEY not set")
-
-    df = pd.DataFrame({"text": [f"Text {i}" for i in range(20)]})
-
-    # Set budget with warning threshold
-    pipeline = (
-        PipelineBuilder.create()
-        .from_dataframe(df, input_columns=["text"], output_columns=["result"])
-        .with_prompt("Echo: {{text}}")
-        .with_llm(provider="groq", model="llama-3.3-70b-versatile", api_key=api_key)
-        .with_batch_size(20)
-        .with_processing_batch_size(5)  # 4 API calls
-        .with_max_budget(0.10)  # Should complete within budget
+        .with_prompt("Summarize: {text}")
+        .with_llm(provider="openai", model="test-model", temperature=0.0)
+        .with_processing_batch_size(1)
+        .with_concurrency(1)
+        .with_max_budget(0.50)
         .build()
     )
 
     result = pipeline.execute()
 
-    # Should succeed (budget sufficient)
-    assert result.success, "Pipeline should complete within budget"
-    assert result.costs.total_cost < 0.10, (
-        f"Cost ${result.costs.total_cost:.4f} exceeded budget"
-    )
-
-    print("\nBudget Warning Test Results:")
-    print("  Budget: $0.10")
-    print(f"  Actual cost: ${result.costs.total_cost:.4f}")
-    print("  ✅ Completed within budget")
+    assert result.success
+    assert result.costs.total_cost == Decimal("0.48")
+    warning_messages = [call.args[0] for call in mock_warning.call_args_list]
+    assert any("75% used" in message for message in warning_messages)
+    assert any("90% used" in message for message in warning_messages)

--- a/tests/integration/test_checkpoint_resume_e2e.py
+++ b/tests/integration/test_checkpoint_resume_e2e.py
@@ -1,208 +1,178 @@
-"""
-E2E test for checkpoint and resume functionality.
+"""Integration tests for checkpoint and resume behavior."""
 
-Validates that pipelines can crash mid-execution and resume from
-the last checkpoint without data loss.
-"""
-
-import os
-import tempfile
+import json
 from decimal import Decimal
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import UUID
 
 import pandas as pd
 import pytest
 
 from ondine import PipelineBuilder
+from ondine.core.models import LLMResponse
+
+
+def _extract_row_number(prompt: str) -> int:
+    for i in range(10):
+        if f"Item {i}" in prompt:
+            return i
+    raise AssertionError(f"Could not extract row from prompt: {prompt}")
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize(
-    ("provider", "model", "api_key_env"),
-    [
-        ("openai", "gpt-4o-mini", "OPENAI_API_KEY"),
-        ("groq", "llama-3.3-70b-versatile", "GROQ_API_KEY"),
-    ],
-)
-def test_checkpoint_and_resume_after_budget_stop(provider, model, api_key_env):
+@patch("ondine.adapters.provider_registry.ProviderRegistry.get")
+def test_checkpoint_resume_restores_partial_progress_without_reprocessing(mock_get):
     """
-    Test checkpoint/resume by using budget limit to force a stop.
-
-    Simulates a crash by hitting budget limit, then resumes to completion.
+    Regression this catches:
+    a resumed run must not redo already completed rows after a checkpointed crash.
     """
-    api_key = os.getenv(api_key_env)
-    if not api_key:
-        pytest.skip(f"{api_key_env} not set")
+    df = pd.DataFrame({"text": [f"Item {i}" for i in range(5)]})
+    all_calls: list[int] = []
+    crash_once = {"triggered": False}
 
-    # Create test data
-    df = pd.DataFrame({"text": [f"Text {i}" for i in range(30)]})
+    async def mock_invoke(prompt, **kwargs):
+        row_num = _extract_row_number(prompt)
+        all_calls.append(row_num)
+        if row_num == 2 and not crash_once["triggered"]:
+            crash_once["triggered"] = True
+            raise RuntimeError("simulated crash")
 
-    # Use temp directory for checkpoints
-    with tempfile.TemporaryDirectory() as tmpdir:
+        return LLMResponse(
+            text=f"done_{row_num}",
+            tokens_in=10,
+            tokens_out=5,
+            model="test-model",
+            cost=Decimal("0.10"),
+            latency_ms=10.0,
+        )
+
+    mock_client = Mock()
+    mock_client.ainvoke = AsyncMock(side_effect=mock_invoke)
+    mock_client.start = AsyncMock()
+    mock_client.stop = AsyncMock()
+    mock_client.router = None
+    mock_client.model = "test-model"
+    mock_client.spec = Mock(
+        model="test-model",
+        input_cost_per_1k_tokens=Decimal("0.10"),
+        output_cost_per_1k_tokens=Decimal("0.10"),
+    )
+    mock_client_class = Mock(return_value=mock_client)
+    mock_get.return_value = mock_client_class
+
+    with TemporaryDirectory() as tmpdir:
         checkpoint_dir = Path(tmpdir)
 
-        # PHASE 1: Run with low budget (will stop partway)
-        pipeline_phase1 = (
+        pipeline = (
             PipelineBuilder.create()
             .from_dataframe(df, input_columns=["text"], output_columns=["result"])
-            .with_prompt("Echo: {{text}}")
-            .with_llm(
-                provider=provider,
-                model=model,
-                api_key=api_key,
-                temperature=0.0,
-                input_cost_per_1k_tokens=Decimal("0.00015"),
-                output_cost_per_1k_tokens=Decimal("0.0006"),
-            )
-            .with_batch_size(30)
-            .with_processing_batch_size(5)  # 6 API calls total
-            .with_max_budget(0.0003)  # Very low budget (will stop after ~2 calls)
-            .with_checkpoint_dir(str(checkpoint_dir))
-            .build()
-        )
-
-        # Execute Phase 1 (should raise BudgetExceededError)
-        from ondine.utils.budget_controller import BudgetExceededError
-
-        session_id = None
-        try:
-            pipeline_phase1.execute()
-            pytest.fail("Phase 1 should have raised BudgetExceededError")
-        except BudgetExceededError as e:
-            # Budget exceeded - this is expected!
-            print(f"\n{provider.upper()} Checkpoint Test - Phase 1:")
-            print(f"  Budget exceeded: {e}")
-
-            # Get checkpoint ID from error message or find checkpoint file
-            checkpoint_files = list(checkpoint_dir.glob("*.json"))
-            assert len(checkpoint_files) > 0, (
-                "No checkpoint file created after budget exceeded"
-            )
-
-            checkpoint_file = checkpoint_files[0]
-            # Extract UUID from filename (strip "checkpoint_" prefix)
-            session_id = checkpoint_file.stem.replace("checkpoint_", "")
-            print(f"  Checkpoint saved: {session_id}")
-
-        # PHASE 2: Resume from checkpoint with higher budget
-        pipeline_phase2 = (
-            PipelineBuilder.create()
-            .from_dataframe(df, input_columns=["text"], output_columns=["result"])
-            .with_prompt("Echo: {{text}}")
-            .with_llm(
-                provider=provider,
-                model=model,
-                api_key=api_key,
-                temperature=0.0,
-                input_cost_per_1k_tokens=Decimal("0.00015"),
-                output_cost_per_1k_tokens=Decimal("0.0006"),
-            )
-            .with_batch_size(30)
-            .with_processing_batch_size(5)
-            .with_max_budget(0.50)  # Higher budget to complete
-            .with_checkpoint_dir(str(checkpoint_dir))
-            .build()
-        )
-
-        # Resume from checkpoint
-        from uuid import UUID
-
-        result_phase2 = pipeline_phase2.execute(resume_from=UUID(session_id))
-
-        # Verify phase 2 completed
-        assert result_phase2.success, f"{provider} phase 2 should have completed"
-        assert len(result_phase2.data) == 30, (
-            f"Should have all 30 rows after resume. Got {len(result_phase2.data)}"
-        )
-
-        print(f"\n{provider.upper()} Checkpoint Test - Phase 2:")
-        print(f"  Completed: {len(result_phase2.data)}/30 rows")
-        print(f"  Total cost: ${result_phase2.costs.total_cost:.4f}")
-        print("  ✅ Checkpoint & resume working correctly")
-
-
-@pytest.mark.integration
-def test_checkpoint_prevents_duplicate_work():
-    """
-    Test that resuming from checkpoint doesn't re-process completed rows.
-
-    Validates that checkpointing saves progress correctly.
-    """
-    api_key = os.getenv("GROQ_API_KEY")
-    if not api_key:
-        pytest.skip("GROQ_API_KEY not set")
-
-    df = pd.DataFrame({"text": [f"Unique_{i}" for i in range(10)]})
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        checkpoint_dir = Path(tmpdir)
-
-        # Phase 1: Process first 5 rows (force stop with budget)
-        pipeline1 = (
-            PipelineBuilder.create()
-            .from_dataframe(df, input_columns=["text"], output_columns=["result"])
-            .with_prompt("Return exactly: {{text}}")
-            .with_llm(
-                provider="groq",
-                model="llama-3.3-70b-versatile",
-                api_key=api_key,
-                temperature=0.0,
-                input_cost_per_1k_tokens=Decimal("0.00059"),
-                output_cost_per_1k_tokens=Decimal("0.00079"),
-            )
-            .with_batch_size(10)
-            .with_processing_batch_size(1)  # 10 API calls
-            .with_max_budget(0.0005)  # Stop after ~3-4 rows
-            .with_checkpoint_dir(str(checkpoint_dir))
-            .build()
-        )
-
-        # Execute Phase 1 (should raise BudgetExceededError)
-        from ondine.utils.budget_controller import BudgetExceededError
-
-        try:
-            pipeline1.execute()
-            pytest.fail("Should have raised BudgetExceededError")
-        except BudgetExceededError:
-            # Expected - budget exceeded
-            pass
-
-        # Phase 2: Resume (should only process remaining rows)
-        checkpoint_files = list(checkpoint_dir.glob("*.json"))
-        assert len(checkpoint_files) > 0, "No checkpoint created"
-        # Extract UUID from filename (strip "checkpoint_" prefix)
-        session_id = checkpoint_files[0].stem.replace("checkpoint_", "")
-
-        pipeline2 = (
-            PipelineBuilder.create()
-            .from_dataframe(df, input_columns=["text"], output_columns=["result"])
-            .with_prompt("Return exactly: {{text}}")
-            .with_llm(
-                provider="groq",
-                model="llama-3.3-70b-versatile",
-                api_key=api_key,
-                temperature=0.0,
-                input_cost_per_1k_tokens=Decimal("0.00059"),
-                output_cost_per_1k_tokens=Decimal("0.00079"),
-            )
-            .with_batch_size(10)
+            .with_prompt("Process: {text}")
+            .with_llm(provider="groq", model="test-model", temperature=0.0)
             .with_processing_batch_size(1)
-            .with_max_budget(0.50)
+            .with_concurrency(1)
+            .with_error_policy("fail")
             .with_checkpoint_dir(str(checkpoint_dir))
             .build()
         )
 
-        from uuid import UUID
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            pipeline.execute()
 
-        result2 = pipeline2.execute(resume_from=UUID(session_id))
+        checkpoint_files = list(checkpoint_dir.glob("*.json"))
+        assert len(checkpoint_files) == 1, "Checkpoint should be written after crash"
 
-        # Verify completion
-        assert result2.success, "Phase 2 should complete"
-        assert len(result2.data) == 10, (
-            f"Should have all 10 rows. Got {len(result2.data)}"
+        checkpoint_payload = json.loads(checkpoint_files[0].read_text())
+        checkpoint_data = checkpoint_payload["data"]
+        assert checkpoint_data["last_processed_row"] == 1
+        assert len(checkpoint_data["intermediate_data"]["completed_responses"]) == 2
+
+        resumed = (
+            PipelineBuilder.create()
+            .from_dataframe(df, input_columns=["text"], output_columns=["result"])
+            .with_prompt("Process: {text}")
+            .with_llm(provider="groq", model="test-model", temperature=0.0)
+            .with_processing_batch_size(1)
+            .with_concurrency(1)
+            .with_error_policy("fail")
+            .with_checkpoint_dir(str(checkpoint_dir))
+            .build()
         )
 
-        print("\nDuplicate Work Prevention Test:")
-        print(f"  Phase 2 completed: {len(result2.data)} rows")
-        print(f"  Total cost: ${result2.costs.total_cost:.4f}")
-        print("  ✅ Resume from checkpoint working")
+        result = resumed.execute(
+            resume_from=UUID(checkpoint_files[0].stem.replace("checkpoint_", ""))
+        )
+
+        output = result.to_pandas()
+        assert result.success
+        assert output["result"].tolist() == [
+            "done_0",
+            "done_1",
+            "done_2",
+            "done_3",
+            "done_4",
+        ]
+
+        assert all_calls == [0, 1, 2, 2, 3, 4]
+        assert all_calls.count(0) == 1
+        assert all_calls.count(1) == 1
+        assert all_calls.count(2) == 2
+
+
+@pytest.mark.integration
+@patch("ondine.adapters.provider_registry.ProviderRegistry.get")
+def test_checkpoint_contains_completed_response_records(mock_get):
+    """
+    Regression this catches:
+    checkpoints must persist enough completed response data to rebuild final output.
+    """
+    df = pd.DataFrame({"text": [f"Item {i}" for i in range(3)]})
+
+    async def mock_invoke(prompt, **kwargs):
+        row_num = _extract_row_number(prompt)
+        if row_num == 1:
+            raise RuntimeError("checkpoint me")
+
+        return LLMResponse(
+            text=f"value_{row_num}",
+            tokens_in=8,
+            tokens_out=4,
+            model="test-model",
+            cost=Decimal("0.05"),
+            latency_ms=5.0,
+        )
+
+    mock_client = Mock()
+    mock_client.ainvoke = AsyncMock(side_effect=mock_invoke)
+    mock_client.start = AsyncMock()
+    mock_client.stop = AsyncMock()
+    mock_client.router = None
+    mock_client.model = "test-model"
+    mock_client.spec = Mock(model="test-model")
+    mock_get.return_value = Mock(return_value=mock_client)
+
+    with TemporaryDirectory() as tmpdir:
+        checkpoint_dir = Path(tmpdir)
+        pipeline = (
+            PipelineBuilder.create()
+            .from_dataframe(df, input_columns=["text"], output_columns=["result"])
+            .with_prompt("Process: {text}")
+            .with_llm(provider="groq", model="test-model", temperature=0.0)
+            .with_processing_batch_size(1)
+            .with_concurrency(1)
+            .with_error_policy("fail")
+            .with_checkpoint_dir(str(checkpoint_dir))
+            .build()
+        )
+
+        with pytest.raises(RuntimeError, match="checkpoint me"):
+            pipeline.execute()
+
+        checkpoint_file = next(checkpoint_dir.glob("*.json"))
+        checkpoint_data = json.loads(checkpoint_file.read_text())["data"]
+        completed = checkpoint_data["intermediate_data"]["completed_responses"]
+
+        assert len(completed) == 1
+        assert completed[0]["text"] == "value_0"
+        assert completed[0]["row_metadata"]["row_index"] == 0

--- a/tests/integration/test_cli_e2e.py
+++ b/tests/integration/test_cli_e2e.py
@@ -6,13 +6,18 @@ Tests the full CLI workflow with real providers to catch regressions.
 
 import os
 import tempfile
+from decimal import Decimal
 from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
 
 import pandas as pd
 import pytest
 from click.testing import CliRunner
 
+from ondine.api import Pipeline
 from ondine.cli.main import cli
+from ondine.config import ConfigLoader
+from ondine.core.models import LLMResponse
 
 
 @pytest.mark.integration
@@ -306,10 +311,104 @@ def test_cli_resume_invalid_session_id():
     result = runner.invoke(cli, ["resume", "--session-id", "invalid-uuid-123"])
 
     assert result.exit_code != 0
-    # Should show some error (format, not found, or implementation error)
-    assert "error" in result.output.lower()
+    assert "invalid session id" in result.output.lower()
 
     print("\n✅ CLI resume handles invalid session ID (fails gracefully)")
+
+
+@pytest.mark.integration
+@patch("ondine.adapters.provider_registry.ProviderRegistry.get")
+def test_cli_resume_executes_from_checkpoint(mock_get):
+    """
+    Regression test for real CLI resume execution.
+
+    This catches the old placeholder behavior where the CLI could discover a
+    checkpoint but could not actually resume the pipeline.
+    """
+    runner = CliRunner()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data_file = Path(tmpdir) / "input.csv"
+        output_file = Path(tmpdir) / "output.csv"
+        checkpoint_dir = Path(tmpdir) / "checkpoints"
+        checkpoint_dir.mkdir()
+        pd.DataFrame({"text": ["Item 0", "Item 1", "Item 2"]}).to_csv(
+            data_file, index=False
+        )
+
+        config_file = Path(tmpdir) / "config.yaml"
+        config_file.write_text(f"""
+data:
+  source:
+    type: csv
+    path: {data_file}
+  input_columns: [text]
+  output_columns: [result]
+prompt:
+  template: "Process: {{{{ text }}}}"
+llm:
+  provider: groq
+  model: test-model
+  temperature: 0.0
+processing:
+  batch_size: 1
+  concurrency: 1
+  checkpoint_dir: {checkpoint_dir}
+  error_policy: fail
+output:
+  format: csv
+  destination_path: {output_file}
+""")
+
+        seen = {"Item 1": 0}
+
+        async def mock_invoke(prompt, **kwargs):
+            text = prompt.split(": ", 1)[1]
+            if text == "Item 1" and seen["Item 1"] == 0:
+                seen["Item 1"] += 1
+                raise RuntimeError("simulated cli crash")
+
+            return LLMResponse(
+                text=f"done::{text}",
+                tokens_in=10,
+                tokens_out=5,
+                model="test-model",
+                cost=Decimal("0.01"),
+                latency_ms=5.0,
+            )
+
+        mock_client = Mock()
+        mock_client.ainvoke = AsyncMock(side_effect=mock_invoke)
+        mock_client.start = AsyncMock()
+        mock_client.stop = AsyncMock()
+        mock_client.router = None
+        mock_client.model = "test-model"
+        mock_client.spec = Mock(model="test-model")
+        mock_get.return_value = Mock(return_value=mock_client)
+
+        specs = ConfigLoader.from_yaml(config_file)
+        pipeline = Pipeline(specs)
+        with pytest.raises(RuntimeError, match="simulated cli crash"):
+            pipeline.execute()
+
+        checkpoint_file = next(checkpoint_dir.glob("*.json"))
+        session_id = checkpoint_file.stem.replace("checkpoint_", "")
+
+        result = runner.invoke(
+            cli,
+            ["resume", "-s", session_id, "-c", str(config_file)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "resume complete" in result.output.lower()
+        assert output_file.exists()
+
+        output_df = pd.read_csv(output_file)
+        assert output_df["result"].tolist() == [
+            "done::Item 0",
+            "done::Item 1",
+            "done::Item 2",
+        ]
 
 
 @pytest.mark.integration

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -8,12 +8,14 @@ import os
 from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import AsyncMock, Mock, patch
 from uuid import UUID
 
 import pandas as pd
 import pytest
 
 from ondine import PipelineBuilder
+from ondine.core.models import LLMResponse
 from ondine.stages import JSONParser
 
 
@@ -344,6 +346,144 @@ class TestEndToEndWithMock:
         validation = pipeline.validate()
         assert validation.is_valid is False
         assert len(validation.errors) > 0
+
+    @patch("ondine.adapters.provider_registry.ProviderRegistry.get")
+    def test_error_policy_skip_marks_failed_rows_and_continues(self, mock_get):
+        """
+        Regression this catches:
+        SKIP must preserve successful rows while marking only the failed row.
+        """
+        df = pd.DataFrame({"text": ["good-1", "bad-row", "good-2"]})
+
+        async def mock_invoke(prompt, **kwargs):
+            value = prompt.split(": ", 1)[1]
+            if value == "bad-row":
+                raise RuntimeError("boom")
+            return LLMResponse(
+                text=f"ok::{value}",
+                tokens_in=10,
+                tokens_out=5,
+                model="test-model",
+                cost=Decimal("0.01"),
+                latency_ms=5.0,
+            )
+
+        mock_client = Mock()
+        mock_client.ainvoke = AsyncMock(side_effect=mock_invoke)
+        mock_client.start = AsyncMock()
+        mock_client.stop = AsyncMock()
+        mock_client.router = None
+        mock_client.model = "test-model"
+        mock_client.spec = Mock(model="test-model")
+        mock_get.return_value = Mock(return_value=mock_client)
+
+        pipeline = (
+            PipelineBuilder.create()
+            .from_dataframe(df, input_columns=["text"], output_columns=["result"])
+            .with_prompt("Process: {text}")
+            .with_llm(provider="groq", model="test-model")
+            .with_processing_batch_size(1)
+            .with_concurrency(1)
+            .with_error_policy("skip")
+            .build()
+        )
+
+        result = pipeline.execute()
+        output = result.to_pandas()
+
+        assert result.success
+        assert output["result"].tolist() == ["ok::good-1", "[SKIPPED]", "ok::good-2"]
+
+    @patch("ondine.adapters.provider_registry.ProviderRegistry.get")
+    def test_error_policy_fail_raises_immediately(self, mock_get):
+        """
+        Regression this catches:
+        FAIL must stop execution and propagate the underlying error.
+        """
+        df = pd.DataFrame({"text": ["good-1", "bad-row", "good-2"]})
+
+        async def mock_invoke(prompt, **kwargs):
+            value = prompt.split(": ", 1)[1]
+            if value == "bad-row":
+                raise RuntimeError("boom")
+            return LLMResponse(
+                text=f"ok::{value}",
+                tokens_in=10,
+                tokens_out=5,
+                model="test-model",
+                cost=Decimal("0.01"),
+                latency_ms=5.0,
+            )
+
+        mock_client = Mock()
+        mock_client.ainvoke = AsyncMock(side_effect=mock_invoke)
+        mock_client.start = AsyncMock()
+        mock_client.stop = AsyncMock()
+        mock_client.router = None
+        mock_client.model = "test-model"
+        mock_client.spec = Mock(model="test-model")
+        mock_get.return_value = Mock(return_value=mock_client)
+
+        pipeline = (
+            PipelineBuilder.create()
+            .from_dataframe(df, input_columns=["text"], output_columns=["result"])
+            .with_prompt("Process: {text}")
+            .with_llm(provider="groq", model="test-model")
+            .with_processing_batch_size(1)
+            .with_concurrency(1)
+            .with_error_policy("fail")
+            .build()
+        )
+
+        with pytest.raises(RuntimeError, match="boom"):
+            pipeline.execute()
+
+    @patch("ondine.adapters.provider_registry.ProviderRegistry.get")
+    def test_error_policy_use_default_inserts_default_response(self, mock_get):
+        """
+        Regression this catches:
+        USE_DEFAULT must keep pipeline execution alive with a deterministic fallback.
+        """
+        df = pd.DataFrame({"text": ["good-1", "bad-row", "good-2"]})
+
+        async def mock_invoke(prompt, **kwargs):
+            value = prompt.split(": ", 1)[1]
+            if value == "bad-row":
+                raise RuntimeError("boom")
+            return LLMResponse(
+                text=f"ok::{value}",
+                tokens_in=10,
+                tokens_out=5,
+                model="test-model",
+                cost=Decimal("0.01"),
+                latency_ms=5.0,
+            )
+
+        mock_client = Mock()
+        mock_client.ainvoke = AsyncMock(side_effect=mock_invoke)
+        mock_client.start = AsyncMock()
+        mock_client.stop = AsyncMock()
+        mock_client.router = None
+        mock_client.model = "test-model"
+        mock_client.spec = Mock(model="test-model")
+        mock_get.return_value = Mock(return_value=mock_client)
+
+        pipeline = (
+            PipelineBuilder.create()
+            .from_dataframe(df, input_columns=["text"], output_columns=["result"])
+            .with_prompt("Process: {text}")
+            .with_llm(provider="groq", model="test-model")
+            .with_processing_batch_size(1)
+            .with_concurrency(1)
+            .with_error_policy("use_default")
+            .build()
+        )
+
+        result = pipeline.execute()
+        output = result.to_pandas()
+
+        assert result.success
+        assert output["result"].tolist() == ["ok::good-1", "", "ok::good-2"]
 
 
 class TestExecutionResultContract:

--- a/tests/integration/test_prefix_caching_e2e.py
+++ b/tests/integration/test_prefix_caching_e2e.py
@@ -1,11 +1,8 @@
-"""
-E2E integration tests for prefix caching (prompt caching).
+"""Integration tests for the prefix-caching request path."""
 
-Tests that system messages are properly separated and cached by providers.
-OpenAI and Anthropic automatically cache system messages to reduce costs.
-"""
-
-import os
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -13,200 +10,109 @@ import pytest
 from ondine import PipelineBuilder
 
 
-@pytest.mark.integration
-def test_prefix_caching_groq_e2e():
-    """
-    E2E test for prefix caching with Groq.
-
-    Tests that:
-    - System messages are sent separately from user prompts
-    - Multiple requests with same system message reuse cached prefix
-    - This reduces input token costs significantly
-
-    Note: Groq may not have explicit prompt caching like OpenAI/Anthropic,
-    but proper message structure is still important for future support.
-    """
-    api_key = os.getenv("GROQ_API_KEY")
-    if not api_key:
-        pytest.skip("GROQ_API_KEY not set")
-
-    # Create test data with multiple rows (same system message, different prompts)
-    df = pd.DataFrame(
-        {
-            "question": [
-                "What is 2+2?",
-                "What is 3+3?",
-                "What is 5+5?",
-                "What is 10+10?",
-                "What is 20+20?",
-            ]
-        }
+def _fake_completion_response(text: str, cost: Decimal, cached_tokens: int):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text))],
+        usage=SimpleNamespace(
+            prompt_tokens=100,
+            completion_tokens=20,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=cached_tokens),
+            cache_read_input_tokens=cached_tokens,
+        ),
+        model="gpt-4o-mini",
+        _hidden_params={"response_cost": float(cost)},
     )
-
-    # Long system message (perfect candidate for caching!)
-    system_message = """You are an expert mathematics tutor with 20 years of experience.
-You specialize in explaining concepts clearly and concisely.
-Always provide the answer first, then a brief explanation.
-Use simple language suitable for high school students.
-Be encouraging and positive in your responses.
-Focus on building confidence in mathematical reasoning."""
-
-    # Build pipeline with system message (should be cached across calls)
-    pipeline = (
-        PipelineBuilder.create()
-        .from_dataframe(df, input_columns=["question"], output_columns=["answer"])
-        .with_prompt(
-            template="{question}",  # User prompt (varies)
-            system_message=system_message,  # System prompt (same for all - cached!)
-        )
-        .with_llm(
-            provider="groq",
-            model="llama-3.3-70b-versatile",
-            api_key=api_key,
-            temperature=0.0,
-            enable_prefix_caching=True,  # Enable caching
-        )
-        .with_rate_limit(9)  # Groq rate limit
-        .build()
-    )
-
-    # Execute
-    result = pipeline.execute()
-
-    # Verify
-    df = result.to_pandas()
-    assert result.success, "Pipeline failed"
-    assert len(df) == 5, "Wrong number of rows"
-    assert df["answer"].notnull().all(), "Some answers are null"
-
-    # Verify cost tracking
-    assert result.costs.total_cost > 0, "Cost not tracked"
-    assert result.costs.input_tokens > 0, "Input tokens not tracked"
-
-    # Print results
-    print("\nPrefix Caching E2E (Groq):")
-    print(f"Rows processed: {len(df)}")
-    print(f"Total cost: ${result.costs.total_cost:.4f}")
-    print(f"Input tokens: {result.costs.input_tokens}")
-    print(f"Output tokens: {result.costs.output_tokens}")
-    print(f"Cost per row: ${result.costs.total_cost / len(df):.6f}")
-
-    # Sample answers
-    print("\nSample answers:")
-    for i, row in df.head(3).iterrows():
-        print(f"Q: {row['question']} → A: {row['answer'][:50]}...")
-
-    # Verify message structure was correct
-    # System message should be sent separately for each call
-    # (This is what enables caching at the provider level)
-    print("\n✓ System messages sent separately (enables provider-level caching)")
 
 
 @pytest.mark.integration
-def test_prefix_caching_openai_e2e():
+@patch("ondine.adapters.unified_litellm_client.logger.debug")
+@patch("ondine.adapters.unified_litellm_client.litellm.acompletion")
+def test_prefix_caching_separates_system_message_and_detects_cache_hits(
+    mock_acompletion, mock_debug
+):
     """
-    E2E test for prefix caching with OpenAI.
-
-    OpenAI has explicit prompt caching support that caches system messages
-    automatically, reducing costs significantly for repeated system prompts.
-
-    See: https://platform.openai.com/docs/guides/prompt-caching
+    Regression this catches:
+    system prompts must be sent separately and provider-reported cache hits
+    must flow through the unified client path.
     """
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        pytest.skip("OPENAI_API_KEY not set")
+    captured_messages = []
 
-    # Create test data
-    df = pd.DataFrame({"text": ["Hello", "World", "Test", "Data", "Sample"]})
+    async def fake_acompletion(**kwargs):
+        captured_messages.append(kwargs["messages"])
+        if len(captured_messages) == 1:
+            return _fake_completion_response("positive", Decimal("0.010"), 0)
+        return _fake_completion_response("neutral", Decimal("0.005"), 80)
 
-    # Long system message (will be cached by OpenAI)
-    system_prompt = """You are a professional text analyzer specializing in sentiment analysis.
-Your task is to analyze the emotional tone and sentiment of the provided text.
-Consider context, word choice, and implicit meanings.
-Provide your analysis in a single concise sentence.
-Be objective and evidence-based in your assessments.
-Focus on the primary emotional tone conveyed."""
+    mock_acompletion.side_effect = fake_acompletion
 
-    # Build pipeline
+    system_message = "Classify sentiment. Return one short label only."
+    df = pd.DataFrame({"text": ["I love this", "It is okay"]})
     pipeline = (
         PipelineBuilder.create()
         .from_dataframe(df, input_columns=["text"], output_columns=["sentiment"])
-        .with_prompt(
-            template="Analyze: {text}",
-            system_message=system_prompt,  # OpenAI caches this!
-        )
+        .with_prompt("Analyze: {text}", system_message=system_message)
         .with_llm(
-            provider="openai",
-            model="gpt-4o-mini",
-            api_key=api_key,
-            temperature=0.0,
-            enable_prefix_caching=True,
+            model="openai/gpt-4o-mini", temperature=0.0, enable_prefix_caching=True
         )
-        .with_rate_limit(500)  # OpenAI rate limit
+        .with_processing_batch_size(1)
+        .with_concurrency(1)
         .build()
     )
 
-    # Execute
     result = pipeline.execute()
+    output = result.to_pandas()
 
-    # Verify
-    df = result.to_pandas()
     assert result.success
-    assert len(df) == 5
-    assert df["sentiment"].notnull().all()
-
-    print("\nPrefix Caching E2E (OpenAI):")
-    print(f"Rows: {len(df)}")
-    print(f"Cost: ${result.costs.total_cost:.4f}")
-    print(f"Input tokens: {result.costs.input_tokens}")
-    print("Note: OpenAI automatically cached the system message!")
-    print("      (Repeat calls with same system message = 50% cost reduction)")
+    assert output["sentiment"].tolist() == ["positive", "neutral"]
+    assert result.costs.total_cost == Decimal("0.015")
+    assert result.costs.input_tokens == 200
+    assert len(captured_messages) == 2
+    assert all(messages[0]["role"] == "system" for messages in captured_messages)
+    assert all(
+        messages[0]["content"] == system_message for messages in captured_messages
+    )
+    assert all(messages[1]["role"] == "user" for messages in captured_messages)
+    assert any("Cache hit!" in call.args[0] for call in mock_debug.call_args_list)
 
 
 @pytest.mark.integration
-def test_prefix_caching_anthropic_e2e():
+@patch("ondine.adapters.unified_litellm_client.litellm.acompletion")
+def test_prefix_caching_cost_reduction_is_reflected_in_pipeline_totals(
+    mock_acompletion,
+):
     """
-    E2E test for prefix caching with Anthropic.
-
-    Anthropic has explicit prompt caching that caches system messages
-    and long contexts automatically.
-
-    See: https://docs.anthropic.com/claude/docs/prompt-caching
+    Regression this catches:
+    provider-reported lower cached-call cost must be reflected in final totals.
     """
-    api_key = os.getenv("ANTHROPIC_API_KEY")
-    if not api_key:
-        pytest.skip("ANTHROPIC_API_KEY not set")
+    costs = [Decimal("0.012"), Decimal("0.004")]
 
-    df = pd.DataFrame({"task": ["Summarize", "Analyze", "Review"]})
+    async def fake_acompletion(**kwargs):
+        idx = fake_acompletion.call_index
+        fake_acompletion.call_index += 1
+        cached_tokens = 0 if idx == 0 else 90
+        return _fake_completion_response(f"answer_{idx}", costs[idx], cached_tokens)
 
-    # Long system message (Anthropic caches this automatically)
-    system_prompt = """You are Claude, an AI assistant created by Anthropic.
-You are helpful, harmless, and honest in all your responses.
-Your goal is to provide accurate, thoughtful, and nuanced answers.
-You should be direct and concise while still being thorough.
-You should acknowledge uncertainty when appropriate.
-You should avoid speculation and stick to factual information."""
+    fake_acompletion.call_index = 0
+    mock_acompletion.side_effect = fake_acompletion
 
     pipeline = (
         PipelineBuilder.create()
-        .from_dataframe(df, input_columns=["task"], output_columns=["result"])
-        .with_prompt(template="{task} this text", system_message=system_prompt)
-        .with_llm(
-            provider="anthropic",
-            model="claude-3-5-haiku-20241022",
-            api_key=api_key,
-            temperature=0.0,
-            enable_prefix_caching=True,
+        .from_dataframe(
+            pd.DataFrame({"question": ["Q1", "Q2"]}),
+            input_columns=["question"],
+            output_columns=["answer"],
         )
+        .with_prompt("{question}", system_message="Answer succinctly.")
+        .with_llm(
+            model="openai/gpt-4o-mini", temperature=0.0, enable_prefix_caching=True
+        )
+        .with_processing_batch_size(1)
+        .with_concurrency(1)
         .build()
     )
 
     result = pipeline.execute()
-    df = result.to_pandas()
 
     assert result.success
-    assert len(df) == 3
-
-    print("\nPrefix Caching E2E (Anthropic):")
-    print(f"Cost: ${result.costs.total_cost:.4f}")
-    print("Note: Anthropic cached the system message automatically!")
+    assert result.costs.total_cost == sum(costs, Decimal("0"))
+    assert result.to_pandas()["answer"].tolist() == ["answer_0", "answer_1"]

--- a/tests/integration/test_preprocessing_and_retry_e2e.py
+++ b/tests/integration/test_preprocessing_and_retry_e2e.py
@@ -1,365 +1,173 @@
-"""
-End-to-end tests for preprocessing and auto-retry features.
-
-These tests ensure the full pipeline works with:
-- Input preprocessing enabled
-- Auto-retry for null/empty outputs
-- Quality validation
-"""
+"""Integration tests for preprocessing, retry, and quality validation."""
 
 from decimal import Decimal
+from unittest.mock import AsyncMock, Mock, patch
 
 import pandas as pd
+import pytest
 
 from ondine import PipelineBuilder
-from ondine.core.specifications import ErrorPolicy
+from ondine.core.models import LLMResponse
 
 
-class TestPreprocessingE2E:
-    """End-to-end tests for preprocessing feature."""
+def _build_mock_client(side_effect):
+    mock_client = Mock()
+    mock_client.ainvoke = AsyncMock(side_effect=side_effect)
+    mock_client.start = AsyncMock()
+    mock_client.stop = AsyncMock()
+    mock_client.router = None
+    mock_client.model = "test-model"
+    mock_client.spec = Mock(model="test-model")
+    return mock_client
 
-    def test_preprocessing_configuration(self):
-        """Should configure preprocessing correctly."""
-        # Create test data with noise
-        df = pd.DataFrame(
-            {"text": ["PRODUCT®  ITEM™", "PREMIUM\n\nQUALITY", "TOP    GRADE"]}
-        )
+
+class TestPreprocessingAndRetryE2E:
+    """Behavioral integration tests for preprocessing and retry."""
+
+    @patch("ondine.adapters.provider_registry.ProviderRegistry.get")
+    def test_preprocessing_cleans_input_before_llm_call(self, mock_get):
+        """
+        Regression this catches:
+        preprocessing must clean noisy input before prompt rendering reaches the LLM.
+        """
+        prompts = []
+
+        async def mock_invoke(prompt, **kwargs):
+            prompts.append(prompt)
+            return LLMResponse(
+                text="clean",
+                tokens_in=10,
+                tokens_out=5,
+                model="test-model",
+                cost=Decimal("0.01"),
+                latency_ms=5.0,
+            )
+
+        mock_get.return_value = Mock(return_value=_build_mock_client(mock_invoke))
 
         pipeline = (
             PipelineBuilder.create()
-            .from_dataframe(df, input_columns=["text"], output_columns=["cleaned"])
-            .with_prompt(template="Clean: {text}", system_message="You are a cleaner")
-            .with_llm(provider="groq", model="test", temperature=0.0)
-            .with_batch_size(3)
+            .from_dataframe(
+                pd.DataFrame({"text": ["PRODUCT®  ITEM™", "PREMIUM\n\nQUALITY"]}),
+                input_columns=["text"],
+                output_columns=["cleaned"],
+            )
+            .with_prompt("Clean: {text}")
+            .with_llm(provider="groq", model="test-model", temperature=0.0)
+            .with_processing_batch_size(1)
+            .with_concurrency(1)
             .build()
         )
-
-        # Enable preprocessing
         pipeline.specifications.processing.enable_preprocessing = True
         pipeline.specifications.processing.preprocessing_max_length = 100
 
-        # Verify configuration
-        assert pipeline.specifications.processing.enable_preprocessing is True
-        assert pipeline.specifications.processing.preprocessing_max_length == 100
+        result = pipeline.execute()
 
+        assert result.success
+        assert prompts == ["Clean: PRODUCT ITEM", "Clean: PREMIUM QUALITY"]
+        assert all("®" not in prompt and "™" not in prompt for prompt in prompts)
+        assert all("\n" not in prompt and "  " not in prompt for prompt in prompts)
 
-class TestAutoRetryE2E:
-    """End-to-end tests for auto-retry feature."""
+    @patch("ondine.adapters.provider_registry.ProviderRegistry.get")
+    def test_preprocessing_and_auto_retry_restore_quality(self, mock_get):
+        """
+        Regression this catches:
+        preprocessing and auto-retry together should recover rows that initially
+        return empty output.
+        """
+        call_counts = {"NOISY PRODUCT": 0, "CLEAN ITEM": 0}
 
-    def test_auto_retry_recovers_null_outputs(self):
-        """Should retry rows with null outputs and recover them."""
-        # Create test data
-        df = pd.DataFrame({"text": ["row1", "row2", "row3", "row4", "row5"]})
+        async def mock_invoke(prompt, **kwargs):
+            text = prompt.split(": ", 1)[1]
+            call_counts[text] = call_counts.get(text, 0) + 1
 
-        # Mock LLM that returns nulls for some rows, then succeeds on retry
-        call_count = {"count": 0}
+            if text == "NOISY PRODUCT" and call_counts[text] == 1:
+                response_text = ""
+            else:
+                response_text = f"cleaned::{text}"
 
-        def mock_invoke(prompt, **kwargs):
-            call_count["count"] += 1
-            # First pass: fail rows 2 and 4
-            if call_count["count"] <= 5:
-                if "row2" in prompt or "row4" in prompt:
-                    return type(
-                        "Response",
-                        (),
-                        {
-                            "message": type("Message", (), {"content": ""})(),
-                            "additional_kwargs": {
-                                "usage": {"prompt_tokens": 10, "completion_tokens": 10}
-                            },
-                        },
-                    )()
-            # Second pass (retry): succeed
-            return type(
-                "Response",
-                (),
-                {
-                    "message": type(
-                        "Message", (), {"content": f"cleaned_{prompt[-4:]}"}
-                    )(),
-                    "additional_kwargs": {
-                        "usage": {"prompt_tokens": 10, "completion_tokens": 10}
-                    },
-                },
-            )()
+            return LLMResponse(
+                text=response_text,
+                tokens_in=10,
+                tokens_out=5,
+                model="test-model",
+                cost=Decimal("0.01"),
+                latency_ms=5.0,
+            )
+
+        mock_get.return_value = Mock(return_value=_build_mock_client(mock_invoke))
 
         pipeline = (
             PipelineBuilder.create()
-            .from_dataframe(df, input_columns=["text"], output_columns=["cleaned"])
-            .with_prompt(template="Clean: {text}")
-            .with_llm(provider="groq", model="test", temperature=0.0)
-            .with_batch_size(5)
+            .from_dataframe(
+                pd.DataFrame({"text": ["NOISY®  PRODUCT™", "CLEAN ITEM"]}),
+                input_columns=["text"],
+                output_columns=["cleaned"],
+            )
+            .with_prompt("Clean: {text}")
+            .with_llm(provider="groq", model="test-model", temperature=0.0)
+            .with_processing_batch_size(1)
+            .with_concurrency(1)
             .build()
         )
-
-        # Enable auto-retry
+        pipeline.specifications.processing.enable_preprocessing = True
+        pipeline.specifications.processing.preprocessing_max_length = 100
         pipeline.specifications.processing.auto_retry_failed = True
         pipeline.specifications.processing.max_retry_attempts = 1
 
-        # Mock the LLM client
-        # (In real test, we'd use proper mocking)
+        result = pipeline.execute()
+        output = result.to_pandas()
+        quality = result.validate_output_quality(["cleaned"])
 
-        # For now, just verify the config is set correctly
-        assert pipeline.specifications.processing.auto_retry_failed is True
-        assert pipeline.specifications.processing.max_retry_attempts == 1
+        assert result.success
+        assert output["cleaned"].tolist() == [
+            "cleaned::NOISY PRODUCT",
+            "cleaned::CLEAN ITEM",
+        ]
+        assert call_counts["NOISY PRODUCT"] == 2
+        assert call_counts["CLEAN ITEM"] == 1
+        assert quality.success_rate == 100.0
 
-    def test_auto_retry_detects_empty_strings(self):
-        """Should retry rows with empty string outputs."""
-        df = pd.DataFrame({"text": ["row1", "row2", "row3"]})
+    @patch("ondine.adapters.provider_registry.ProviderRegistry.get")
+    def test_quality_report_generated_from_real_execution(self, mock_get):
+        """
+        Regression this catches:
+        post-execution quality validation must detect persistent empty outputs.
+        """
 
-        pipeline = (
-            PipelineBuilder.create()
-            .from_dataframe(df, input_columns=["text"], output_columns=["cleaned"])
-            .with_prompt(template="Clean: {text}")
-            .with_llm(provider="groq", model="test", temperature=0.0)
-            .build()
-        )
-
-        # Enable auto-retry
-        pipeline.specifications.processing.auto_retry_failed = True
-        pipeline.specifications.processing.max_retry_attempts = 2
-
-        # Verify configuration
-        assert pipeline.specifications.processing.auto_retry_failed is True
-
-    def test_auto_retry_stops_at_acceptable_quality(self):
-        """Should stop retrying once quality reaches 70%."""
-        df = pd.DataFrame({"text": [f"row{i}" for i in range(100)]})
-
-        pipeline = (
-            PipelineBuilder.create()
-            .from_dataframe(df, input_columns=["text"], output_columns=["cleaned"])
-            .with_prompt(template="Clean: {text}")
-            .with_llm(provider="groq", model="test", temperature=0.0)
-            .build()
-        )
-
-        # Enable auto-retry
-        pipeline.specifications.processing.auto_retry_failed = True
-        pipeline.specifications.processing.max_retry_attempts = 3
-
-        # Verify max attempts respected
-        assert pipeline.specifications.processing.max_retry_attempts == 3
-
-
-class TestQualityValidationE2E:
-    """End-to-end tests for quality validation."""
-
-    def test_quality_report_generated_after_execution(self):
-        """Should generate quality report after execution."""
-        df = pd.DataFrame({"text": ["test1", "test2", "test3"]})
-
-        pipeline = (
-            PipelineBuilder.create()
-            .from_dataframe(df, input_columns=["text"], output_columns=["cleaned"])
-            .with_prompt(template="Clean: {text}")
-            .with_llm(provider="groq", model="test", temperature=0.0)
-            .build()
-        )
-
-        # Would execute and check quality
-        # result = pipeline.execute()
-        # quality = result.validate_output_quality(['cleaned'])
-        # assert quality.total_rows == 3
-
-        # For now, just verify pipeline is configured
-        assert pipeline.specifications.dataset.output_columns == ["cleaned"]
-
-    def test_quality_validation_detects_poor_results(self):
-        """Should detect when quality is below acceptable threshold."""
-        # Simulate a result with poor quality
-        from datetime import datetime
-        from uuid import uuid4
-
-        from ondine.core.models import (
-            CostEstimate,
-            ExecutionResult,
-            ProcessingStats,
-        )
-
-        # Create result with 30% nulls (should be flagged)
-        df = pd.DataFrame({"output": ["valid"] * 70 + [None] * 30})
-
-        result = ExecutionResult(
-            data=df,
-            metrics=ProcessingStats(100, 100, 0, 0, 1.0, 10.0),
-            costs=CostEstimate(Decimal("0.01"), 100, 50, 50, 100),
-            execution_id=uuid4(),
-            start_time=datetime.now(),
-        )
-
-        quality = result.validate_output_quality(["output"])
-
-        # Should be acceptable (70%)
-        assert quality.success_rate == 70.0
-        assert quality.is_acceptable  # Use == for numpy compatibility
-
-        # But should have warnings
-        assert len(quality.issues) > 0
-
-
-class TestFullPipelineE2E:
-    """Full end-to-end test with all features enabled."""
-
-    def test_preprocessing_plus_retry_improves_quality(self):
-        """Should show quality improvement from preprocessing + retry."""
-        # Create realistic test data with noise
-        df = pd.DataFrame(
-            {
-                "desc": [
-                    "PRODUCT®  ITEM™    PREMIUM",  # Noisy
-                    "HIGH\n\nQUALITY    GRADE",  # Noisy
-                    "CERTIFIED    AUTHENTIC®",  # Noisy
-                    "PROFESSIONAL™  SERIES",  # Noisy
-                    "STANDARD PRODUCT",  # Clean
-                ]
-            }
-        )
-
-        pipeline = (
-            PipelineBuilder.create()
-            .from_dataframe(df, input_columns=["desc"], output_columns=["cleaned"])
-            .with_prompt(
-                template="Clean this product description: {desc}",
-                system_message="Return cleaned description only",
-            )
-            .with_llm(
-                provider="groq", model="test-model", temperature=0.0, max_tokens=100
-            )
-            .with_batch_size(5)
-            .with_max_retries(2)
-            .build()
-        )
-
-        # Enable both features
-        pipeline.specifications.processing.enable_preprocessing = True
-        pipeline.specifications.processing.preprocessing_max_length = 200
-        pipeline.specifications.processing.auto_retry_failed = True
-        pipeline.specifications.processing.max_retry_attempts = 2
-
-        # Verify configuration is correct
-        assert pipeline.specifications.processing.enable_preprocessing is True
-        assert pipeline.specifications.processing.auto_retry_failed is True
-        assert pipeline.specifications.processing.max_retry_attempts == 2
-        assert pipeline.specifications.processing.preprocessing_max_length == 200
-
-        # In real test, would execute and verify:
-        # result = pipeline.execute()
-        # quality = result.validate_output_quality(['cleaned'])
-        # assert quality.success_rate >= 80.0  # Should be better than without features
-
-    def test_config_driven_preprocessing_and_retry(self):
-        """Should work when configured via YAML/dict."""
-        from ondine.core.specifications import (
-            DatasetSpec,
-            DataSourceType,
-            LLMProvider,
-            LLMSpec,
-            PipelineSpecifications,
-            ProcessingSpec,
-            PromptSpec,
-        )
-
-        # Create specs programmatically (simulates loading from YAML)
-        specs = PipelineSpecifications(
-            dataset=DatasetSpec(
-                source_type=DataSourceType.DATAFRAME,
-                input_columns=["text"],
-                output_columns=["cleaned"],
-            ),
-            prompt=PromptSpec(
-                template="Clean: {text}",
-                system_message="Be concise",
-            ),
-            llm=LLMSpec(
-                provider=LLMProvider.GROQ,
+        async def mock_invoke(prompt, **kwargs):
+            text = prompt.split(": ", 1)[1]
+            response_text = "" if text == "bad" else f"ok::{text}"
+            return LLMResponse(
+                text=response_text,
+                tokens_in=10,
+                tokens_out=5,
                 model="test-model",
-                temperature=0.0,
-                max_tokens=100,
-            ),
-            processing=ProcessingSpec(
-                batch_size=10,
-                concurrency=3,
-                max_retries=3,
-                error_policy=ErrorPolicy.SKIP,
-                enable_preprocessing=True,  # NEW
-                preprocessing_max_length=500,  # NEW
-                auto_retry_failed=True,  # NEW
-                max_retry_attempts=2,  # NEW
-            ),
-        )
+                cost=Decimal("0.01"),
+                latency_ms=5.0,
+            )
 
-        # Verify all settings
-        assert specs.processing.enable_preprocessing is True
-        assert specs.processing.auto_retry_failed is True
-        assert specs.processing.max_retry_attempts == 2
-        assert specs.processing.preprocessing_max_length == 500
+        mock_get.return_value = Mock(return_value=_build_mock_client(mock_invoke))
 
-
-class TestRegressionPrevention:
-    """Tests to prevent specific bugs from recurring."""
-
-    def test_pipeline_init_without_observers(self):
-        """Should initialize Pipeline without observers parameter (regression test)."""
-        from ondine.api.pipeline import Pipeline
-        from ondine.core.specifications import (
-            DatasetSpec,
-            DataSourceType,
-            LLMProvider,
-            LLMSpec,
-            PipelineSpecifications,
-            ProcessingSpec,
-            PromptSpec,
-        )
-
-        specs = PipelineSpecifications(
-            dataset=DatasetSpec(
-                source_type=DataSourceType.DATAFRAME,
+        pipeline = (
+            PipelineBuilder.create()
+            .from_dataframe(
+                pd.DataFrame({"text": ["good", "bad", "good-2"]}),
                 input_columns=["text"],
                 output_columns=["cleaned"],
-            ),
-            prompt=PromptSpec(template="Clean: {text}"),
-            llm=LLMSpec(provider=LLMProvider.GROQ, model="test"),
-            processing=ProcessingSpec(),
+            )
+            .with_prompt("Clean: {text}")
+            .with_llm(provider="groq", model="test-model", temperature=0.0)
+            .with_processing_batch_size(1)
+            .with_concurrency(1)
+            .build()
         )
 
-        df = pd.DataFrame({"text": ["test"]})
+        result = pipeline.execute()
+        quality = result.validate_output_quality(["cleaned"])
 
-        # This should NOT raise TypeError about 'observers' keyword
-        pipeline = Pipeline(specs, dataframe=df)
-
-        assert pipeline is not None
-        assert pipeline.specifications == specs
-
-    def test_dataframe_boolean_check_in_retry(self):
-        """Should not use DataFrame in boolean context (regression test)."""
-        df1 = pd.DataFrame({"a": [1, 2, 3]})
-        df2 = pd.DataFrame({"b": [4, 5, 6]})
-
-        # This was causing: "truth value of DataFrame is ambiguous"
-        # WRONG: result = df1 or df2
-
-        # CORRECT:
-        result = df1 if df1 is not None else df2
-        assert result is not None
-
-        # Also test with None
-        df_none = None
-        result2 = df_none if df_none is not None else df2
-        assert result2.equals(df2)
-
-    def test_null_vs_empty_detection(self):
-        """Should detect both nulls and empty strings as failures (regression test)."""
-        df = pd.DataFrame({"output": ["valid", None, "", "  ", "valid"]})
-
-        # Simulate retry detection logic
-        output_col = df["output"]
-        null_mask = output_col.isna()
-        empty_mask = output_col.astype(str).str.strip() == ""
-        failed_mask = null_mask | empty_mask
-
-        failed_count = failed_mask.sum()
-
-        # Should detect: None (index 1), '' (index 2), '  ' (index 3) = 3 failures
-        assert failed_count == 3
-        assert list(df[failed_mask].index) == [1, 2, 3]
+        assert quality.total_rows == 3
+        assert quality.empty_outputs == 1
+        assert quality.valid_outputs == 2
+        assert quality.success_rate == pytest.approx(66.6666666, rel=1e-4)
+        assert quality.is_acceptable is False

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,10 +2,12 @@
 
 import tempfile
 from pathlib import Path
+from uuid import uuid4
 
 import pandas as pd
 from click.testing import CliRunner
 
+from ondine.adapters import LocalFileCheckpointStorage
 from ondine.cli.main import cli
 
 
@@ -115,3 +117,71 @@ class TestCLI:
 
         assert result.exit_code != 0
         assert "Invalid session ID" in result.output or "Error" in result.output
+
+    def test_resume_requires_config_for_existing_checkpoint(self):
+        """Test resume reports missing config for real checkpoints."""
+        checkpoint_dir = Path(self.temp_dir) / "checkpoints"
+        checkpoint_dir.mkdir()
+        session_id = uuid4()
+        storage = LocalFileCheckpointStorage(checkpoint_dir)
+        storage.save(
+            session_id,
+            {
+                "session_id": str(session_id),
+                "pipeline_id": str(uuid4()),
+                "start_time": "2026-03-08T00:00:00",
+                "end_time": None,
+                "current_stage_index": 2,
+                "last_processed_row": 1,
+                "total_rows": 3,
+                "accumulated_cost": "0.20",
+                "accumulated_tokens": 10,
+                "intermediate_data": {},
+                "failed_rows": 0,
+                "skipped_rows": 0,
+            },
+        )
+
+        result = self.runner.invoke(
+            cli,
+            ["resume", "-s", str(session_id), "--checkpoint-dir", str(checkpoint_dir)],
+        )
+
+        assert result.exit_code != 0
+        assert "requires the original pipeline config" in result.output.lower()
+
+    def test_list_checkpoints_shows_current_checkpoint_fields(self):
+        """Test list-checkpoints renders current CheckpointInfo fields."""
+        checkpoint_dir = Path(self.temp_dir) / "checkpoints"
+        checkpoint_dir.mkdir()
+
+        session_id = uuid4()
+        storage = LocalFileCheckpointStorage(checkpoint_dir)
+        storage.save(
+            session_id,
+            {
+                "session_id": str(session_id),
+                "pipeline_id": str(uuid4()),
+                "start_time": "2026-03-07T00:00:00",
+                "end_time": None,
+                "current_stage_index": 3,
+                "last_processed_row": 4,
+                "total_rows": 10,
+                "accumulated_cost": "1.23",
+                "accumulated_tokens": 100,
+                "intermediate_data": {},
+                "failed_rows": 0,
+                "skipped_rows": 0,
+            },
+        )
+
+        result = self.runner.invoke(
+            cli, ["list-checkpoints", "--checkpoint-dir", str(checkpoint_dir)]
+        )
+
+        assert result.exit_code == 0
+        assert str(session_id)[:8] in result.output
+        assert "4" in result.output
+        assert "10" in result.output
+        assert "1.23" in result.output
+        assert "3" in result.output

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -1,18 +1,28 @@
 """Unit tests for Pipeline class."""
 
+import asyncio
+from datetime import datetime
 from decimal import Decimal
+from unittest.mock import patch
 
 import pandas as pd
+import polars as pl
+import pytest
 
+from ondine.adapters.containers.result_container import ResultContainerImpl
 from ondine.api.pipeline import Pipeline
+from ondine.core.models import CostEstimate, ExecutionResult, ProcessingStats
 from ondine.core.specifications import (
     DatasetSpec,
     DataSourceType,
     LLMProvider,
     LLMSpec,
     PipelineSpecifications,
+    ProcessingSpec,
     PromptSpec,
 )
+from ondine.orchestration import StreamingExecutor
+from ondine.utils.budget_controller import BudgetExceededError
 
 
 class TestPipeline:
@@ -164,3 +174,316 @@ class TestPipeline:
         pipeline = Pipeline(specs, executor=executor)
 
         assert pipeline.executor == executor
+
+    def test_execute_stream_uses_async_streaming_path(self):
+        """Test execute_stream delegates to execute_stream_async instead of execute()."""
+        df = pd.DataFrame({"text": ["a", "b", "c"]})
+        specs = PipelineSpecifications(
+            dataset=DatasetSpec(
+                source_type=DataSourceType.DATAFRAME,
+                input_columns=["text"],
+                output_columns=["result"],
+            ),
+            prompt=PromptSpec(template="{text}"),
+            llm=LLMSpec(provider=LLMProvider.OPENAI, model="gpt-4o-mini"),
+            metadata={
+                "streaming": {
+                    "enabled": True,
+                    "chunk_size": 2,
+                    "max_pending_chunks": 4,
+                }
+            },
+        )
+        pipeline = Pipeline(
+            specs, dataframe=df, executor=StreamingExecutor(chunk_size=2)
+        )
+
+        chunk_result = ExecutionResult(
+            data=pd.DataFrame({"text": ["a"], "result": ["A"]}),
+            metrics=ProcessingStats(
+                total_rows=1,
+                processed_rows=1,
+                failed_rows=0,
+                skipped_rows=0,
+            ),
+            costs=CostEstimate(
+                total_cost=Decimal("0.01"),
+                total_tokens=10,
+                input_tokens=5,
+                output_tokens=5,
+                rows=1,
+                confidence="actual",
+            ),
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            success=True,
+        )
+
+        captured = {}
+
+        async def fake_execute_stream_async(
+            chunk_size: int, max_pending_chunks: int, output_path=None
+        ):
+            captured["chunk_size"] = chunk_size
+            captured["max_pending_chunks"] = max_pending_chunks
+            captured["output_path"] = output_path
+            yield chunk_result
+
+        with (
+            patch.object(
+                pipeline,
+                "execute",
+                side_effect=AssertionError("execute() should not be used"),
+            ),
+            patch.object(
+                pipeline,
+                "execute_stream_async",
+                side_effect=fake_execute_stream_async,
+            ),
+        ):
+            results = list(pipeline.execute_stream())
+
+        assert results == [chunk_result]
+        assert captured == {
+            "chunk_size": 2,
+            "max_pending_chunks": 4,
+            "output_path": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_execute_stream_async_enforces_budget_across_chunks(self):
+        """Test streaming budget enforcement uses cumulative chunk cost."""
+        df = pd.DataFrame({"text": ["a", "b", "c"]})
+        specs = PipelineSpecifications(
+            dataset=DatasetSpec(
+                source_type=DataSourceType.DATAFRAME,
+                input_columns=["text"],
+                output_columns=["result"],
+            ),
+            prompt=PromptSpec(template="{text}"),
+            llm=LLMSpec(provider=LLMProvider.OPENAI, model="gpt-4o-mini"),
+            processing=ProcessingSpec(max_budget=Decimal("0.50")),
+        )
+        pipeline = Pipeline(
+            specs, dataframe=df, executor=StreamingExecutor(chunk_size=1)
+        )
+
+        chunk_frames = [
+            pl.DataFrame({"text": ["a"]}),
+            pl.DataFrame({"text": ["b"]}),
+            pl.DataFrame({"text": ["c"]}),
+        ]
+        processed_chunks = []
+
+        async def fake_stream_dataframe_chunks(dataframe, chunk_size):
+            for chunk in chunk_frames:
+                yield chunk
+
+        async def fake_process_chunk_async(chunk_df, execution_id, chunk_index):
+            processed_chunks.append(chunk_index)
+            return ExecutionResult(
+                data=pd.DataFrame(
+                    {
+                        "text": chunk_df["text"].tolist(),
+                        "result": [
+                            value.upper() for value in chunk_df["text"].tolist()
+                        ],
+                    }
+                ),
+                metrics=ProcessingStats(
+                    total_rows=len(chunk_df),
+                    processed_rows=len(chunk_df),
+                    failed_rows=0,
+                    skipped_rows=0,
+                ),
+                costs=CostEstimate(
+                    total_cost=Decimal("0.30"),
+                    total_tokens=10,
+                    input_tokens=5,
+                    output_tokens=5,
+                    rows=len(chunk_df),
+                    confidence="actual",
+                ),
+                start_time=datetime.now(),
+                end_time=datetime.now(),
+                success=True,
+            )
+
+        with (
+            patch.object(
+                pipeline,
+                "_stream_dataframe_chunks",
+                side_effect=fake_stream_dataframe_chunks,
+            ),
+            patch.object(
+                pipeline,
+                "_process_chunk_async",
+                side_effect=fake_process_chunk_async,
+            ),
+            pytest.raises(BudgetExceededError, match="Budget exceeded"),
+        ):
+            async for _ in pipeline.execute_stream_async(chunk_size=1):
+                pass
+
+        assert processed_chunks == [0, 1]
+
+    @pytest.mark.asyncio
+    async def test_execute_stream_async_prefetches_using_max_pending_chunks(self):
+        """Test async streaming prefetches source chunks up to the pending limit."""
+        df = pd.DataFrame({"text": ["a", "b", "c"]})
+        specs = PipelineSpecifications(
+            dataset=DatasetSpec(
+                source_type=DataSourceType.DATAFRAME,
+                input_columns=["text"],
+                output_columns=["result"],
+            ),
+            prompt=PromptSpec(template="{text}"),
+            llm=LLMSpec(provider=LLMProvider.OPENAI, model="gpt-4o-mini"),
+        )
+        pipeline = Pipeline(
+            specs, dataframe=df, executor=StreamingExecutor(chunk_size=1)
+        )
+
+        chunk_frames = [
+            pl.DataFrame({"text": ["a"]}),
+            pl.DataFrame({"text": ["b"]}),
+            pl.DataFrame({"text": ["c"]}),
+        ]
+        yielded_chunks = []
+        release_first_chunk = asyncio.Event()
+
+        async def fake_stream_dataframe_chunks(dataframe, chunk_size):
+            for idx, chunk in enumerate(chunk_frames):
+                yielded_chunks.append(idx)
+                yield chunk
+
+        async def fake_process_chunk_async(chunk_df, execution_id, chunk_index):
+            if chunk_index == 0:
+                await release_first_chunk.wait()
+            return ExecutionResult(
+                data=pd.DataFrame(
+                    {
+                        "text": chunk_df["text"].tolist(),
+                        "result": [
+                            value.upper() for value in chunk_df["text"].tolist()
+                        ],
+                    }
+                ),
+                metrics=ProcessingStats(
+                    total_rows=len(chunk_df),
+                    processed_rows=len(chunk_df),
+                    failed_rows=0,
+                    skipped_rows=0,
+                ),
+                costs=CostEstimate(
+                    total_cost=Decimal("0.10"),
+                    total_tokens=10,
+                    input_tokens=5,
+                    output_tokens=5,
+                    rows=len(chunk_df),
+                    confidence="actual",
+                ),
+                start_time=datetime.now(),
+                end_time=datetime.now(),
+                success=True,
+            )
+
+        with (
+            patch.object(
+                pipeline,
+                "_stream_dataframe_chunks",
+                side_effect=fake_stream_dataframe_chunks,
+            ),
+            patch.object(
+                pipeline,
+                "_process_chunk_async",
+                side_effect=fake_process_chunk_async,
+            ),
+        ):
+            stream = pipeline.execute_stream_async(chunk_size=1, max_pending_chunks=2)
+            first_chunk_task = asyncio.create_task(anext(stream))
+
+            for _ in range(20):
+                if len(yielded_chunks) >= 2:
+                    break
+                await asyncio.sleep(0.01)
+
+            assert len(yielded_chunks) >= 2
+
+            release_first_chunk.set()
+            first_chunk = await first_chunk_task
+            remaining_chunks = [chunk async for chunk in stream]
+
+        assert first_chunk.metrics.processed_rows == 1
+        assert len(remaining_chunks) == 2
+
+    @pytest.mark.asyncio
+    async def test_execute_stream_async_writes_result_container_output(self, tmp_path):
+        """Test streamed output writing handles ResultContainerImpl chunk data."""
+        df = pd.DataFrame({"text": ["a", "b"]})
+        output_path = tmp_path / "streamed.csv"
+        specs = PipelineSpecifications(
+            dataset=DatasetSpec(
+                source_type=DataSourceType.DATAFRAME,
+                input_columns=["text"],
+                output_columns=["result"],
+            ),
+            prompt=PromptSpec(template="{text}"),
+            llm=LLMSpec(provider=LLMProvider.OPENAI, model="gpt-4o-mini"),
+        )
+        pipeline = Pipeline(
+            specs, dataframe=df, executor=StreamingExecutor(chunk_size=1)
+        )
+
+        async def fake_stream_dataframe_chunks(dataframe, chunk_size):
+            yield pl.DataFrame({"text": ["a"]})
+            yield pl.DataFrame({"text": ["b"]})
+
+        async def fake_process_chunk_async(chunk_df, execution_id, chunk_index):
+            rows = [
+                {"text": value, "result": value.upper()}
+                for value in chunk_df["text"].tolist()
+            ]
+            return ExecutionResult(
+                data=ResultContainerImpl(rows, columns=["text", "result"]),
+                metrics=ProcessingStats(
+                    total_rows=len(rows),
+                    processed_rows=len(rows),
+                    failed_rows=0,
+                    skipped_rows=0,
+                ),
+                costs=CostEstimate(
+                    total_cost=Decimal("0.10"),
+                    total_tokens=10,
+                    input_tokens=5,
+                    output_tokens=5,
+                    rows=len(rows),
+                    confidence="actual",
+                ),
+                start_time=datetime.now(),
+                end_time=datetime.now(),
+                success=True,
+            )
+
+        with (
+            patch.object(
+                pipeline,
+                "_stream_dataframe_chunks",
+                side_effect=fake_stream_dataframe_chunks,
+            ),
+            patch.object(
+                pipeline,
+                "_process_chunk_async",
+                side_effect=fake_process_chunk_async,
+            ),
+        ):
+            results = [
+                chunk
+                async for chunk in pipeline.execute_stream_async(
+                    chunk_size=1, output_path=output_path
+                )
+            ]
+
+        assert len(results) == 2
+        written = pd.read_csv(output_path)
+        assert written["result"].tolist() == ["A", "B"]

--- a/tests/unit/test_streaming_loader.py
+++ b/tests/unit/test_streaming_loader.py
@@ -1,6 +1,7 @@
 """Unit tests for StreamingDataLoader."""
 
 from pathlib import Path
+from unittest.mock import Mock
 
 import polars as pl
 import pytest
@@ -100,6 +101,19 @@ class TestStreamingDataLoader:
         # Verify data integrity
         total_rows = sum(len(c) for c in chunks)
         assert total_rows == 100
+
+    def test_iter_chunks_csv_does_not_collect_full_dataset(self, sample_csv: Path):
+        """Test CSV chunking avoids LazyFrame.collect full materialization."""
+        loader = StreamingDataLoader(sample_csv, chunk_size=30)
+        loader._lazy_frame.collect = Mock(
+            side_effect=AssertionError("should not collect")
+        )
+
+        chunks = list(loader.iter_chunks())
+
+        assert len(chunks) == 4
+        assert sum(len(chunk) for chunk in chunks) == 100
+        loader._lazy_frame.collect.assert_not_called()
 
     def test_iter_chunks_exact_multiple(self, tmp_path: Path):
         """Test chunking when rows are exact multiple of chunk_size."""

--- a/tests/unit/test_unified_litellm_minimal.py
+++ b/tests/unit/test_unified_litellm_minimal.py
@@ -41,9 +41,18 @@ class FakeChoice:
 class FakeResponse:
     """Fake LiteLLM response object."""
 
-    def __init__(self, content="hello", prompt_tokens=10, completion_tokens=5):
+    def __init__(
+        self,
+        content="hello",
+        prompt_tokens=10,
+        completion_tokens=5,
+        model=None,
+        hidden_params=None,
+    ):
         self.choices = [FakeChoice(FakeMessage(content))]
         self.usage = FakeUsage(prompt_tokens, completion_tokens)
+        self.model = model
+        self._hidden_params = hidden_params or {}
 
 
 class TestUnifiedLiteLLMClient:
@@ -170,6 +179,103 @@ class TestUnifiedLiteLLMClient:
             mock_router_instance.acompletion.assert_called_once()
             assert client.router is not None
 
+    @pytest.mark.asyncio
+    async def test_router_response_preserves_actual_deployment_metadata(self):
+        """Test router responses preserve the actual deployment id used."""
+        router_config = {
+            "model_list": [
+                {"model_name": "fast-model", "litellm_params": {"model": "groq/llama"}},
+                {
+                    "model_name": "fast-model",
+                    "litellm_params": {"model": "openai/gpt-4o-mini"},
+                },
+            ]
+        }
+        spec = LLMSpec(model="fast-model", api_key="sk-test")
+        spec.router_config = router_config
+        fake_response = FakeResponse(
+            "fallback response",
+            model="mixed-llm",
+            hidden_params={"model_id": "openai-fallback"},
+        )
+
+        with patch("litellm.Router") as mock_router:
+            mock_router_instance = Mock()
+            mock_router_instance.acompletion = AsyncMock(return_value=fake_response)
+            mock_router_instance.model_list = router_config["model_list"]
+            mock_router.return_value = mock_router_instance
+
+            client = UnifiedLiteLLMClient(spec)
+            result = await client.ainvoke("test")
+
+            assert result.text == "fallback response"
+            assert result.metadata["model_id"] == "openai-fallback"
+
+    def test_router_init_disables_invalid_mixed_model_names(self):
+        """Test router init safely disables invalid load-balancing config."""
+        spec = LLMSpec(model="router", api_key="sk-test")
+        spec.router_config = {
+            "model_list": [
+                {"model_name": "primary", "litellm_params": {"model": "groq/llama"}},
+                {
+                    "model_name": "secondary",
+                    "litellm_params": {"model": "openai/gpt-4o-mini"},
+                },
+            ]
+        }
+
+        with patch("litellm.Router") as mock_router:
+            client = UnifiedLiteLLMClient(spec)
+
+            mock_router.assert_not_called()
+            assert client.router is None
+
+    def test_router_cooldown_callback_emits_observer_event(self):
+        """Test router cooldown hook emits Ondine observer events."""
+        spec = LLMSpec(model="fast-model", api_key="sk-test")
+        spec.router_config = {
+            "model_list": [
+                {
+                    "model_name": "fast-model",
+                    "litellm_params": {"model": "groq/llama-3.3-70b"},
+                }
+            ]
+        }
+
+        with patch("litellm.Router") as mock_router:
+            mock_router_instance = Mock()
+            mock_router_instance.acompletion = AsyncMock()
+            mock_router_instance.model_list = spec.router_config["model_list"]
+            mock_router_instance.deployment_callback_on_failure = Mock(
+                return_value=True
+            )
+            mock_router.return_value = mock_router_instance
+
+            client = UnifiedLiteLLMClient(spec)
+            dispatcher = Mock()
+            client.set_observer_dispatcher(dispatcher)
+
+            client.router.deployment_callback_on_failure(
+                {
+                    "model": "fast-model",
+                    "exception": RuntimeError("rate limited"),
+                    "litellm_params": {
+                        "model": "groq/llama-3.3-70b",
+                        "model_info": {"id": "groq-primary"},
+                    },
+                },
+                None,
+                None,
+                None,
+            )
+
+            dispatcher.dispatch.assert_called_once()
+            event = dispatcher.dispatch.call_args.args[1]
+            assert dispatcher.dispatch.call_args.args[0] == "provider_cooldown"
+            assert event.provider == "groq/llama-3.3-70b"
+            assert event.deployment_id == "groq-primary"
+            assert "rate limited" in event.reason
+
     def test_invoke_script_mode(self):
         """Test invoke() works in script mode (no running loop)."""
         spec = LLMSpec(model="openai/gpt-4o-mini", api_key="sk-test")
@@ -282,6 +388,51 @@ class TestUnifiedLiteLLMClient:
             # Verify response is serialized JSON
             assert '"result"' in result.text
             assert "structured output" in result.text
+
+    @pytest.mark.asyncio
+    async def test_structured_router_preserves_deployment_metadata(self):
+        """Test structured router responses preserve fallback deployment metadata."""
+
+        class TestModel(BaseModel):
+            result: str
+
+        spec = LLMSpec(model="fast-model", api_key="sk-test")
+        spec.router_config = {
+            "model_list": [
+                {"model_name": "fast-model", "litellm_params": {"model": "groq/llama"}}
+            ]
+        }
+
+        mock_instructor_client = Mock()
+        mock_completions = Mock()
+        mock_result = TestModel(result="structured output")
+        mock_raw_response = Mock()
+        mock_raw_response.usage = Mock(prompt_tokens=10, completion_tokens=5)
+        mock_raw_response._hidden_params = {"model_region": "groq-region-a"}
+
+        mock_completions.create_with_completion = AsyncMock(
+            return_value=(mock_result, mock_raw_response)
+        )
+        mock_completions.create = AsyncMock(return_value=mock_result)
+        mock_instructor_client.chat = Mock()
+        mock_instructor_client.chat.completions = mock_completions
+
+        with (
+            patch("litellm.Router") as mock_router,
+            patch(
+                "ondine.adapters.unified_litellm_client.instructor.from_litellm",
+                return_value=mock_instructor_client,
+            ),
+        ):
+            mock_router_instance = Mock()
+            mock_router_instance.acompletion = AsyncMock()
+            mock_router_instance.model_list = spec.router_config["model_list"]
+            mock_router.return_value = mock_router_instance
+
+            client = UnifiedLiteLLMClient(spec)
+            result = await client.structured_invoke_async("test", TestModel)
+
+            assert result.metadata["model_id"] == "groq-region-a"
 
     def test_calc_cost_with_litellm(self):
         """Test cost calculation uses LiteLLM's pricing DB."""


### PR DESCRIPTION
## Summary
- harden streamed execution by fixing sync-to-async streaming behavior, cumulative budget enforcement, incremental writer handling, and true chunked loader paths
- make checkpoint resume and checkpoint listing reflect real persisted state, including resume execution and current stage visibility
- strengthen router and resilience coverage by wiring cooldown observability to LiteLLM's real failure callback path and expanding high-risk E2E/unit regressions

## Test plan
- [x] pre-commit unit test suite passed during commit
- [x] `uv run pytest tests/unit/test_pipeline.py -q`
- [x] `uv run pytest tests/integration/test_streaming_pipeline.py tests/integration/test_executors_integration.py -q`
- [x] `uv run pytest tests/unit/test_cli.py tests/integration/test_cli_e2e.py -q`
- [x] `uv run pytest tests/unit/test_unified_litellm_minimal.py tests/unit/test_resilience.py -q`
- [x] `uv run pytest tests/unit/test_streaming_loader.py -q`
- [x] full test suite run in parallel completed with 3 Anthropic integration failures caused by `claude-3-5-haiku-20241022` returning provider `NotFoundError`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Resume interrupted pipeline runs from checkpoints, preserving completed work.
  * Stream large CSV, Parquet, and NDJSON files without full in-memory materialization.
  * Budget enforcement with cost tracking, threshold warnings, and automatic stopping when limits are exceeded.
  * Enhanced CLI resume command supporting configuration and output path overrides.
  * Improved checkpoint metadata tracking for better visibility into execution state.

* **Bug Fixes**
  * Better stage tracking and error handling in checkpoint restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->