### PR TITLE
fix: fail fast when all Router deployments are in cooldown

### DIFF
--- a/ondine/adapters/unified_litellm_client.py
+++ b/ondine/adapters/unified_litellm_client.py
@@ -651,12 +651,12 @@ class UnifiedLiteLLMClient(LLMClient):
         if any(p in error_str for p in auth_patterns):
             return InvalidAPIKeyError(f"Authentication error: {error}")
 
-        # 6. Check for Router cooldown (Retryable — transient rate-limit storm)
+        # 6. Check for Router total failure (Fatal)
         if "no deployments available" in error_str:
-            return OndineRateLimitError(
+            return ModelNotFoundError(
                 "All Router deployments are in cooldown. "
-                "Retrying with backoff. If this persists, check that the model "
-                "name in your deployment config matches the actual deployment. "
+                "This usually means the model name in your deployment config "
+                "does not match what is actually deployed on the endpoint. "
                 f"Original: {error}"
             )
 

--- a/ondine/stages/llm_invocation_stage.py
+++ b/ondine/stages/llm_invocation_stage.py
@@ -1,7 +1,6 @@
 """LLM invocation stage with concurrency and retry logic."""
 
 import asyncio
-import threading
 from decimal import Decimal
 from typing import Any
 
@@ -10,7 +9,6 @@ from pydantic import BaseModel
 from ondine.adapters.llm_client import LLMClient
 from ondine.core.error_handler import ErrorAction, ErrorHandler
 from ondine.core.exceptions import (
-    ConfigurationError,
     InvalidAPIKeyError,
     ModelNotFoundError,
     NonRetryableError,
@@ -158,13 +156,6 @@ class LLMInvocationStage(PipelineStage[list[PromptBatch], list[ResponseBatch]]):
             self._progress_reporter = progress_reporter
             self._total_rows = total_rows
 
-            # Consecutive cooldown breaker: if we see this many cooldown
-            # errors without a single success, treat as fatal config error.
-            self._cooldown_lock = threading.Lock()
-            self._consecutive_cooldowns = 0
-            self._any_success = False
-            self._cooldown_fatal_threshold = 50
-
             # Flatten batches for concurrent processing
             items, batch_map = BatchProcessor.flatten(batches)
 
@@ -250,11 +241,6 @@ class LLMInvocationStage(PipelineStage[list[PromptBatch], list[ResponseBatch]]):
             if response is None:
                 raise RuntimeError("LLM invocation returned None (unexpected)")
 
-            # Success — reset cooldown counter
-            with self._cooldown_lock:
-                self._any_success = True
-                self._consecutive_cooldowns = 0
-
             # Track deployment distribution
             deployment_id = self._extract_deployment_id(response)
             if deployment_id:
@@ -278,8 +264,6 @@ class LLMInvocationStage(PipelineStage[list[PromptBatch], list[ResponseBatch]]):
         except (BudgetExceededError, NonRetryableError):
             raise
         except Exception as e:
-            self._check_cooldown_breaker(e)
-
             response = self._handle_error(e, idx, self._total_rows)
 
             batch_size = BatchProcessor.get_batch_size(item.metadata)
@@ -292,33 +276,6 @@ class LLMInvocationStage(PipelineStage[list[PromptBatch], list[ResponseBatch]]):
             self._update_context(context, idx, item.metadata, response)
 
             return response
-
-    def _check_cooldown_breaker(self, error: Exception) -> None:
-        """Escalate to fatal if all deployments are permanently failing.
-
-        Distinguishes between:
-        - Transient rate-limit storm: some requests succeed, cooldowns are brief
-        - Wrong model config: ZERO successes ever, every request goes to cooldown
-        """
-        error_str = str(error).lower()
-        if (
-            "no deployments available" not in error_str
-            and "all router deployments" not in error_str
-        ):
-            return
-
-        with self._cooldown_lock:
-            self._consecutive_cooldowns += 1
-            if (
-                not self._any_success
-                and self._consecutive_cooldowns >= self._cooldown_fatal_threshold
-            ):
-                raise ConfigurationError(
-                    f"All Router deployments failed {self._consecutive_cooldowns} "
-                    f"consecutive times with zero successes. The model name in "
-                    f"your deployment config likely does not match what is "
-                    f"actually deployed on the endpoint. Original: {error}"
-                )
 
     def _invoke_with_retry_and_ratelimit(
         self,


### PR DESCRIPTION
## Summary

- When all Router deployments enter cooldown (typically caused by a wrong model name in `model_list` config), the pipeline now **aborts immediately** with a clear `ModelNotFoundError` instead of silently skipping thousands of rows and producing cryptic JSON parse errors
- Classify `"No deployments available"` from LiteLLM Router as a `NonRetryableError` with an actionable message: *"the model name in your deployment config does not match what is actually deployed"*
- Propagate all `NonRetryableError` subclasses (`ModelNotFoundError`, `InvalidAPIKeyError`, `QuotaExceededError`, `ConfigurationError`) from `_process_single_item` — these fatal errors can no longer be swallowed by `error_policy=skip`

## Before

```
Skipping row unknown due to error: No deployments available... (×4876)
Failed to parse batch response: Invalid JSON in response (×200)
Pipeline "completes" with 124/5000 rows and zero useful output
```

## After

```
ModelNotFoundError: All Router deployments are in cooldown.
This usually means the model name in your deployment config
does not match what is actually deployed on the endpoint.
```

Pipeline stops at the first occurrence. No wasted time, no misleading output.

## Test plan

- [x] All 623 unit tests pass
- [x] Ruff, bandit, detect-secrets all pass
- [ ] CI green on PR
- [ ] Manual test: use wrong model name in router config → immediate abort with clear message


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved messaging when deployments are unavailable: now maps "no deployments available" to a clearer model-not-found style error with retry/backoff guidance.
  * Preserved existing model-not-found behavior for other cases.
  * Non-retryable failures are now surfaced immediately and treated like budget/exhaustion errors to avoid needless retries and speed up feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->