### PR TITLE
security: exclude compromised litellm 1.82.7 and 1.82.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     # Core LLM integration (using LiteLLM native + Instructor)
-    "litellm>=1.80.0",
+    "litellm>=1.80.0,!=1.82.7,!=1.82.8",
     "instructor>=1.0.0",
     "diskcache>=5.6.0", # For LiteLLM Disk caching
     "aiohttp>=3.9.0", # For high-performance connection pooling

--- a/uv.lock
+++ b/uv.lock
@@ -3438,7 +3438,7 @@ wheels = [
 
 [[package]]
 name = "ondine"
-version = "1.5.3"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -3563,7 +3563,7 @@ requires-dist = [
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "langfuse", marker = "extra == 'all'", specifier = ">=2.0.0" },
     { name = "langfuse", marker = "extra == 'observability'", specifier = ">=2.0.0" },
-    { name = "litellm", specifier = ">=1.80.0" },
+    { name = "litellm", specifier = ">=1.80.0,!=1.82.7,!=1.82.8" },
     { name = "llama-index", marker = "extra == 'all'", specifier = ">=0.12.0" },
     { name = "llama-index", marker = "extra == 'llama-index'", specifier = ">=0.12.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },


### PR DESCRIPTION
## Summary

- **Exclude litellm 1.82.7 and 1.82.8** from dependency resolution by pinning to `>=1.80.0,!=1.82.7,!=1.82.8`
- These versions contain a **malicious `.pth` file** (`litellm_init.pth`) that executes a credential-stealing payload **on every Python interpreter startup** — no `import litellm` required
- The payload exfiltrates SSH keys, cloud credentials (AWS/GCP/Azure/K8s), env vars, crypto wallets, and shell history to `litellm.cloud` (attacker-controlled)
- **Latest safe version: 1.82.6** (confirmed by PyPI + community)

## References

- [BerriAI/litellm#24512 — CRITICAL: Malicious litellm_init.pth credential stealer](https://github.com/BerriAI/litellm/issues/24512)
- [HN: litellm 1.82.7 and 1.82.8 compromised](https://news.ycombinator.com/item?id=47501426)
- [HN: LiteLLM supply-chain attack](https://news.ycombinator.com/item?id=47501729)

## Impact on this project

- Our previous pin `litellm>=1.80.0` **allowed** resolving to the compromised versions on fresh installs
- Current installed version (1.82.0) is **safe**, but any CI run or new contributor could have picked up 1.82.7/1.82.8
- The `!=` exclusions block the compromised versions while keeping the range open for future safe releases (1.82.9+)

## Test plan

- [x] All 635 unit tests pass (623 passed, 12 skipped)
- [x] Pre-commit hooks pass
- [x] Verified no `litellm_init.pth` in local site-packages
- [ ] Verify fresh `uv sync` resolves to 1.82.6 (not 1.82.7/1.82.8)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints to exclude specific problematic versions of the `litellm` library while maintaining compatibility with supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->