### PR TITLE
chore: add community health files for open-source readiness

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,96 @@
+name: Bug Report
+description: File a bug report for Ondine
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report for Ondine! Please provide as much detail as possible to help us reproduce and fix the issue.
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: What operating system are you using?
+      options:
+        - Linux
+        - macOS
+        - Windows
+    validations:
+      required: true
+  - type: dropdown
+    id: python-version
+    attributes:
+      label: Python Version
+      description: What version of Python are you running?
+      options:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+    validations:
+      required: true
+  - type: input
+    id: llm-provider
+    attributes:
+      label: LLM Provider Affected
+      description: Which LLM provider (e.g., OpenAI, Anthropic, local) is affected by this bug?
+      placeholder: ex. OpenAI
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Please provide clear steps to reproduce the behavior.
+      placeholder: |
+        1. Initialize Ondine with...
+        2. Call method...
+        3. Observe error...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-vs-actual
+    attributes:
+      label: Expected vs Actual Behavior
+      description: What did you expect to happen, and what actually happened?
+      placeholder: |
+        Expected: The batch process should complete successfully.
+        Actual: The process crashes with an exception.
+    validations:
+      required: true
+  - type: textarea
+    id: error-traceback
+    attributes:
+      label: Full Error Traceback
+      description: Please copy and paste the full error traceback. This will be automatically formatted into code.
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: minimal-reproduction
+    attributes:
+      label: Minimal Reproduction Code Block
+      description: Provide a minimal, self-contained code snippet that reproduces the issue.
+      render: python
+    validations:
+      required: true
+  - type: input
+    id: ondine-version
+    attributes:
+      label: Ondine Version
+      description: What version of Ondine are you using?
+      placeholder: ex. v1.7.0
+    validations:
+      required: true
+  - type: dropdown
+    id: installation-method
+    attributes:
+      label: Installation Method
+      description: How did you install Ondine?
+      options:
+        - pip
+        - uv
+        - source
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature Request
+description: Suggest an idea or feature for Ondine
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a new feature for Ondine! Please fill out the form below to help us understand your request.
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem Statement
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: A clear and concise description of what the problem is. Ex. I'm always frustrated when...
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like to see implemented in Ondine.
+      placeholder: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or features you've considered.
+      placeholder: Have you tried other approaches? Why didn't they work?
+    validations:
+      required: false
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case / Who Benefits
+      description: Describe the use case and who will benefit from this feature.
+      placeholder: This feature would be useful for... because...
+    validations:
+      required: true
+  - type: dropdown
+    id: willingness-to-contribute
+    attributes:
+      label: Willingness to Contribute
+      description: Are you willing to submit a Pull Request to implement this feature?
+      options:
+        - "Yes"
+        - "No"
+        - "Maybe"
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Description of Change
+
+<!-- Please provide a clear and concise description of the changes made in this pull request. -->
+<!-- Explain the problem this PR solves or the feature it adds. -->
+
+## Linked Issue Number
+
+<!-- If this PR fixes an open issue, please link to it here (e.g., "Fixes #123"). -->
+Fixes #
+
+## Type of Change
+
+<!-- Please check the relevant options below: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+
+## Checklist
+
+<!-- Please verify that you have completed the following steps: -->
+- [ ] I have added or updated tests to cover my changes.
+- [ ] I have updated the documentation accordingly.
+- [ ] `ruff` passes locally with my changes.
+- [ ] `pytest` passes locally with my changes.
+- [ ] I have used the conventional commit format for my commit messages.

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ site/
 # IDE files
 .idea/
 .cursor/
+.claude/
 
 # Generated architecture diagrams (regenerated from model.yaml)
 docs/architecture/diagrams/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -559,4 +559,4 @@ Adds a Textual-based TUI for interactive progress monitoring, a generic pipeline
 
 ---
 
-[1.0.0]: https://github.com/ptimizeroracle/Ondine/releases/tag/v1.0.0
+[1.0.0]: https://github.com/ptimizeroracle/ondine/releases/tag/v1.0.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Ondine Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in the Ondine community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at git@binblok.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,12 @@ Thank you for your interest in contributing to Ondine!
 ## Quick Start
 
 1. **Fork and Clone**
+
+   Click **Fork** on [github.com/ptimizeroracle/ondine](https://github.com/ptimizeroracle/ondine), then clone your fork:
    ```bash
-   git clone https://github.com/<your-username>/ondine.git
+   git clone https://github.com/ptimizeroracle/ondine.git
    cd ondine
+   git remote add upstream https://github.com/ptimizeroracle/ondine.git
    ```
 
 2. **Set Up Development Environment**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Thank you for your interest in contributing to Ondine!
 
 1. **Fork and Clone**
    ```bash
-   git clone https://github.com/YOUR_USERNAME/Ondine.git
-   cd Ondine
+   git clone https://github.com/<your-username>/ondine.git
+   cd ondine
    ```
 
 2. **Set Up Development Environment**
@@ -168,7 +168,7 @@ See `examples/15_custom_llm_provider.py` and `examples/16_custom_pipeline_stage.
 
 ## Reporting Bugs
 
-1. Check if the bug is already reported in [Issues](https://github.com/ptimizeroracle/Ondine/issues)
+1. Check if the bug is already reported in [Issues](https://github.com/ptimizeroracle/ondine/issues)
 2. If not, create a new issue with:
    - Clear title and description
    - Steps to reproduce
@@ -178,7 +178,7 @@ See `examples/15_custom_llm_provider.py` and `examples/16_custom_pipeline_stage.
 
 ## Suggesting Features
 
-1. Check [existing feature requests](https://github.com/ptimizeroracle/Ondine/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
+1. Check [existing feature requests](https://github.com/ptimizeroracle/ondine/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
 2. Open a new issue with:
    - Clear use case description
    - Proposed API or interface
@@ -215,12 +215,12 @@ Maintainers should avoid manual version bumps unless they are intentionally repa
 
 ## Good First Issues
 
-Look for issues labeled [`good first issue`](https://github.com/ptimizeroracle/Ondine/labels/good%20first%20issue) - these are great for newcomers!
+Look for issues labeled [`good first issue`](https://github.com/ptimizeroracle/ondine/labels/good%20first%20issue) - these are great for newcomers!
 
 ## Getting Help
 
-- **Questions?** Open a [Discussion](https://github.com/ptimizeroracle/Ondine/discussions)
-- **Bugs?** Open an [Issue](https://github.com/ptimizeroracle/Ondine/issues)
+- **Questions?** Open a [Discussion](https://github.com/ptimizeroracle/ondine/discussions)
+- **Bugs?** Open an [Issue](https://github.com/ptimizeroracle/ondine/issues)
 - **Chat?** Join our community (link coming soon)
 
 ## Code of Conduct

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
   [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
   [![GitHub stars](https://img.shields.io/github/stars/ptimizeroracle/ondine.svg?style=social)](https://github.com/ptimizeroracle/ondine)
-  [![Tests](https://github.com/ptimizeroracle/Ondine/actions/workflows/ci.yml/badge.svg)](https://github.com/ptimizeroracle/Ondine/actions/workflows/ci.yml)
+  [![Tests](https://github.com/ptimizeroracle/ondine/actions/workflows/ci.yml/badge.svg)](https://github.com/ptimizeroracle/ondine/actions/workflows/ci.yml)
   [![Documentation](https://img.shields.io/badge/docs-MkDocs%20Material-blue.svg)](https://ptimizeroracle.github.io/ondine)
 
   <img src="assets/images/demo.gif" alt="Ondine Demo" width="700"/>
@@ -1072,7 +1072,7 @@ Additional resources:
 
 Contributions welcome! Please follow:
 
-1. Fork the repository at https://github.com/ptimizeroracle/Ondine
+1. Fork the repository at https://github.com/ptimizeroracle/ondine
 2. Create a feature branch
 3. Follow the existing code style (Black, Ruff)
 4. Add tests for new features
@@ -1093,7 +1093,7 @@ MIT License - see LICENSE file for details
 
 ## Support
 
-- **Repository**: https://github.com/ptimizeroracle/Ondine
+- **Repository**: https://github.com/ptimizeroracle/ondine
 - **Issues**: Open an issue on GitHub
 - **Discussions**: Use GitHub Discussions for questions
 - **Email**: git@binblok.com

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+The Ondine team takes the security of our LLM batch processing SDK seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+## Supported Versions
+
+We currently provide security updates for the following versions of Ondine:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| v1.7.0  | :white_check_mark: |
+| < 1.7.0 | :x:                |
+
+If you are using an unsupported version, we strongly recommend upgrading to the latest version.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability within Ondine, please report it to us privately. **Do not disclose the vulnerability publicly until a fix has been released.**
+
+You can report vulnerabilities using one of the following methods:
+
+1. **GitHub Private Security Advisory (Preferred):**
+   Navigate to the [Security tab](https://github.com/ptimizeroracle/ondine/security) of our repository and click the **"Report a vulnerability"** button. This allows you to securely disclose the issue directly to the maintainers.
+
+2. **Email:**
+   Send an email to **git@binblok.com**. Please encrypt your message if possible and include "Security Vulnerability" in the subject line.
+
+### What to Include in Your Report
+
+To help us understand and resolve the issue quickly, please include the following information in your report:
+
+* **Description:** A clear and detailed description of the vulnerability.
+* **Steps to Reproduce:** Step-by-step instructions to reproduce the issue. Include any necessary configuration, code snippets, or sample inputs.
+* **Impact:** The potential impact of the vulnerability (e.g., what an attacker could achieve).
+* **Environment:** The version of Ondine, Python version, and operating system where the vulnerability was observed.
+* **Suggested Fix (Optional):** If you have a proposed solution or patch, please include it.
+
+### Response Service Level Agreement (SLA)
+
+We are committed to resolving security issues in a timely manner. Our target SLAs are as follows:
+
+* **Acknowledgment:** We will acknowledge receipt of your vulnerability report within **48 hours**.
+* **Resolution/Patch:** We aim to provide a fix or mitigation for confirmed vulnerabilities within **90 days** of the initial report.
+
+We will keep you updated on the progress of the investigation and the timeline for a fix.
+
+## Out of Scope
+
+The following types of reports are generally considered out of scope and will not be accepted:
+
+* Vulnerabilities in third-party dependencies (unless they can be uniquely exploited through Ondine's specific usage). Please report these directly to the respective upstream projects.
+* Denial of Service (DoS) attacks against our infrastructure or website.
+* Theoretical vulnerabilities without a proven exploit or clear impact.
+* Issues related to the user's own infrastructure or misconfiguration of the SDK.
+* Spam, social engineering, or phishing attacks against Ondine contributors.
+
+Thank you for helping keep Ondine and its users safe!

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,9 +5,12 @@ Thank you for your interest in contributing to Ondine!
 ## Quick Start
 
 1. **Fork and Clone**
+
+   Click **Fork** on [github.com/ptimizeroracle/ondine](https://github.com/ptimizeroracle/ondine), then clone your fork:
    ```bash
-   git clone https://github.com/<your-username>/ondine.git
+   git clone https://github.com/ptimizeroracle/ondine.git
    cd ondine
+   git remote add upstream https://github.com/ptimizeroracle/ondine.git
    ```
 
 2. **Set Up Development Environment**

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,8 +6,8 @@ Thank you for your interest in contributing to Ondine!
 
 1. **Fork and Clone**
    ```bash
-   git clone https://github.com/YOUR_USERNAME/Ondine.git
-   cd Ondine
+   git clone https://github.com/<your-username>/ondine.git
+   cd ondine
    ```
 
 2. **Set Up Development Environment**
@@ -168,7 +168,7 @@ See `examples/15_custom_llm_provider.py` and `examples/16_custom_pipeline_stage.
 
 ## Reporting Bugs
 
-1. Check if the bug is already reported in [Issues](https://github.com/ptimizeroracle/Ondine/issues)
+1. Check if the bug is already reported in [Issues](https://github.com/ptimizeroracle/ondine/issues)
 2. If not, create a new issue with:
    - Clear title and description
    - Steps to reproduce
@@ -178,7 +178,7 @@ See `examples/15_custom_llm_provider.py` and `examples/16_custom_pipeline_stage.
 
 ## Suggesting Features
 
-1. Check [existing feature requests](https://github.com/ptimizeroracle/Ondine/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
+1. Check [existing feature requests](https://github.com/ptimizeroracle/ondine/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
 2. Open a new issue with:
    - Clear use case description
    - Proposed API or interface
@@ -215,12 +215,12 @@ Maintainers should avoid manual version bumps unless they are intentionally repa
 
 ## Good First Issues
 
-Look for issues labeled [`good first issue`](https://github.com/ptimizeroracle/Ondine/labels/good%20first%20issue) - these are great for newcomers!
+Look for issues labeled [`good first issue`](https://github.com/ptimizeroracle/ondine/labels/good%20first%20issue) - these are great for newcomers!
 
 ## Getting Help
 
-- **Questions?** Open a [Discussion](https://github.com/ptimizeroracle/Ondine/discussions)
-- **Bugs?** Open an [Issue](https://github.com/ptimizeroracle/Ondine/issues)
+- **Questions?** Open a [Discussion](https://github.com/ptimizeroracle/ondine/discussions)
+- **Bugs?** Open an [Issue](https://github.com/ptimizeroracle/ondine/issues)
 - **Chat?** Join our community (link coming soon)
 
 ## Code of Conduct

--- a/docs/guides/azure-managed-identity.md
+++ b/docs/guides/azure-managed-identity.md
@@ -512,5 +512,5 @@ Includes:
 ## Support
 
 For issues or questions:
-- GitHub Issues: https://github.com/ptimizeroracle/Ondine/issues
+- GitHub Issues: https://github.com/ptimizeroracle/ondine/issues
 - Documentation: https://ptimizeroracle.github.io/ondine

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
   <img src="assets/images/ondine-logo.png" alt="Ondine Logo" width="600"/>
 </div>
 
-[![Tests](https://github.com/ptimizeroracle/Ondine/actions/workflows/ci.yml/badge.svg)](https://github.com/ptimizeroracle/Ondine/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/ptimizeroracle/Ondine/branch/main/graph/badge.svg)](https://codecov.io/gh/ptimizeroracle/Ondine)
+[![Tests](https://github.com/ptimizeroracle/ondine/actions/workflows/ci.yml/badge.svg)](https://github.com/ptimizeroracle/ondine/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/ptimizeroracle/ondine/branch/main/graph/badge.svg)](https://codecov.io/gh/ptimizeroracle/ondine)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/ptimizeroracle/Ondine"
-Repository = "https://github.com/ptimizeroracle/Ondine"
+Homepage = "https://github.com/ptimizeroracle/ondine"
+Repository = "https://github.com/ptimizeroracle/ondine"
 Documentation = "https://ptimizeroracle.github.io/ondine"
-Issues = "https://github.com/ptimizeroracle/Ondine/issues"
+Issues = "https://github.com/ptimizeroracle/ondine/issues"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary

- Add `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1 with enforcement contact `git@binblok.com`
- Add `SECURITY.md` — Vulnerability disclosure policy with 48h acknowledgment / 90-day patch SLA, GitHub private advisory + email reporting
- Add `.github/ISSUE_TEMPLATE/bug_report.yml` — YAML form with OS, Python version, LLM provider, traceback, minimal repro, and installation method fields
- Add `.github/ISSUE_TEMPLATE/feature_request.yml` — YAML form with problem statement, proposed solution, use case, and willingness-to-contribute fields
- Add `.github/PULL_REQUEST_TEMPLATE.md` — Checklist covering tests, docs, ruff, pytest, and conventional commit format

## Why

These files are required for GitHub to award the "Community Standards" badge and are table stakes for attracting external contributors. Part of the OSS growth initiative to go from 3 → 1,000+ stars.

## Test plan

- [ ] Verify issue templates appear as forms when opening a new issue on GitHub
- [ ] Verify PR template auto-populates on new PRs
- [ ] Verify Security tab shows the SECURITY.md policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a project Code of Conduct and a Security Policy.
  * Normalized repository links and badges across README, contributing guides, changelog, docs, and package metadata.

* **Chores**
  * Added standardized issue and pull-request templates (bug report and feature request forms, PR checklist).
  * Updated VCS ignores and removed a recorded repository submodule reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->