### PR TITLE
fix: correct GitBook structure paths

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,5 +1,5 @@
 root: ./docs/
 
 structure:
-  readme: ./README.md
-  summary: ./SUMMARY.md
+  readme: ./docs/README.md
+  summary: ./docs/SUMMARY.md


### PR DESCRIPTION
Fix `.gitbook.yaml` — `readme` and `summary` paths under `structure` must be relative to the repo root, not to `root: ./docs/`.

**Before:**
```yaml
structure:
  readme: ./README.md       # ❌ points to repo root README
  summary: ./SUMMARY.md    # ❌ points to repo root SUMMARY (doesn't exist)
```

**After:**
```yaml
structure:
  readme: ./docs/README.md
  summary: ./docs/SUMMARY.md
```

This fixes the "Page not found" error on GitBook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation file organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->