### PR TITLE
docs: fix GitBook image paths + add 4 diagram placeholders

### DIFF
--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -6,7 +6,7 @@ Understanding Ondine's architecture will help you build more sophisticated pipel
 
 Ondine is built on a layered architecture:
 
-![Ondine Architecture Overview](images/architecture-overview.png)
+![Ondine Architecture Overview](getting-started/images/architecture-overview.png)
 
 ## Key Components
 
@@ -92,7 +92,7 @@ pipeline = (
 
 Stages are composable processing units that form a pipeline:
 
-![Pipeline Stages](images/pipeline-stages.png)
+![Pipeline Stages](getting-started/images/pipeline-stages.png)
 
 **Built-in stages:**
 - `DataLoaderStage`: Load data from files/dataframes

--- a/docs/guides/batch-processing.md
+++ b/docs/guides/batch-processing.md
@@ -9,6 +9,15 @@ Multi-row batching aggregates multiple prompts into a single API call, dramatica
 - **Processing time**: 100× faster (69 hours → 42 minutes)
 - **Rate limit issues**: Virtually eliminated
 
+<!-- IMAGE_PLACEHOLDER
+title: Multi-Row Batching Flow
+type: data-flow
+description: Left-to-right data flow with enterprise Stripe/Vercel design language (subtle grid background, 1px connectors, #0F172A/#64748B typography). Left side: a vertical stack of 5 individual row boxes labeled "Row 1" through "Row 5", each with a small document icon. Arrow labeled "batch_size=5" points right to a single large box labeled "Batch Aggregator" with a green left-accent bar — inside show the 5 rows being combined into one JSON array. Single arrow labeled "1 API call" points right to an LLM box (blue left-accent bar, labeled "GPT-4o-mini"). Single arrow labeled "1 response" points right to a "Batch Disaggregator" box (orange left-accent bar) — inside show the JSON response being split back into 5 individual results. 5 arrows fan out right to 5 result boxes. Below the diagram, a comparison bar: "Without batching: 5 API calls, 5× latency" (red, crossed out) vs "With batching: 1 API call, 1× latency" (green, checkmark). Keep spacing generous, cards with subtle shadows.
+placement: full-width
+alt_text: Data flow diagram showing how multi-row batching combines 5 rows into 1 API call through batch aggregation, sends to LLM, then disaggregates the response back into 5 individual results.
+-->
+![Multi-Row Batching Flow](guides/images/multi-row-batching-flow.png)
+
 ## Quick Start
 
 ### Basic Usage

--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -15,7 +15,7 @@ description: A left-to-right flowchart showing the lifecycle of a single pipelin
 placement: full-width
 alt_text: Flowchart showing how a request is hashed, checked against the cache, and either returned immediately on a hit or sent to the LLM API on a miss before the response is stored and returned.
 -->
-![Cache Lookup Request Flow](images/cache-lookup-request-flow.png)
+![Cache Lookup Request Flow](guides/images/cache-lookup-request-flow.png)
 
 ---
 
@@ -174,7 +174,7 @@ description: A side-by-side architecture comparison with two panels. LEFT PANEL 
 placement: full-width
 alt_text: Architecture diagram comparing disk caching with a single process writing to local filesystem versus Redis caching with multiple distributed workers sharing a centralized Redis server with TTL-based expiry.
 -->
-![Disk vs Redis Cache Architecture](images/disk-vs-redis-cache-architecture.png)
+![Disk vs Redis Cache Architecture](guides/images/disk-vs-redis-cache-architecture.png)
 
 **Disk** when you're working locally and want zero-infrastructure caching that sticks around forever.
 

--- a/docs/guides/checkpointing.md
+++ b/docs/guides/checkpointing.md
@@ -20,7 +20,7 @@ description: A horizontal flowchart with five rounded-rect nodes connected by ar
 placement: full-width
 alt_text: Flowchart showing the checkpoint-resume lifecycle: execute, fail at row N, save checkpoint, resume from row N, complete with no duplicate cost.
 -->
-![Checkpoint Resume Lifecycle](images/checkpoint-resume-lifecycle.png)
+![Checkpoint Resume Lifecycle](guides/images/checkpoint-resume-lifecycle.png)
 
 The `StateManager` periodically serialises execution context — last processed row index, accumulated cost, completed responses — into a compressed JSON file:
 
@@ -63,7 +63,7 @@ description: A vertical sequence diagram with two lifelines — "Pipeline Execut
 placement: full-width
 alt_text: Sequence diagram showing the StateManager saving checkpoints to disk at regular intervals as the pipeline executor processes batches of rows.
 -->
-![StateManager Periodic Save Cycle](images/statemanager-periodic-save-cycle.png)
+![StateManager Periodic Save Cycle](guides/images/statemanager-periodic-save-cycle.png)
 
 ### `with_checkpoint_interval(rows: int)`
 

--- a/docs/guides/context-store.md
+++ b/docs/guides/context-store.md
@@ -20,7 +20,7 @@ description: A left-to-right pipeline diagram showing six stages as rounded boxe
 placement: full-width
 alt_text: Data flow diagram of the six-stage anti-hallucination pipeline: evidence priming, LLM inference, grounding verification, contradiction detection, confidence scoring, and storage, with a feedback loop from storage back to evidence priming for subsequent runs.
 -->
-![Anti-Hallucination Pipeline Lifecycle](images/anti-hallucination-pipeline-lifecycle.png)
+![Anti-Hallucination Pipeline Lifecycle](guides/images/anti-hallucination-pipeline-lifecycle.png)
 
 ---
 
@@ -250,7 +250,7 @@ description: A top-to-bottom flowchart showing how grounding verification decide
 placement: full-width
 alt_text: Flowchart showing grounding verification: LLM response is scored against source text via TF-IDF and optional dense embeddings, then compared to the threshold. Grounded responses pass through; ungrounded ones are flagged, retried, or skipped depending on the configured action.
 -->
-![Grounding Verification Flow](images/grounding-verification-flow.png)
+![Grounding Verification Flow](guides/images/grounding-verification-flow.png)
 
 ```python
 # Basic grounding with flag action
@@ -481,7 +481,7 @@ description: A three-column comparison diagram showing the three store backends 
 placement: full-width
 alt_text: Side-by-side comparison of the three context store backends — RustContextStore (persistent, full-featured), ZepContextStore (cloud-hosted with entity extraction but no grounding), and InMemoryContextStore (ephemeral pure-Python fallback) — showing their capabilities, storage model, and search features.
 -->
-![Context Store Backend Comparison](images/context-store-backend-comparison.png)
+![Context Store Backend Comparison](guides/images/context-store-backend-comparison.png)
 
 | Requirement | Backend |
 |---|---|

--- a/docs/guides/cost-control.md
+++ b/docs/guides/cost-control.md
@@ -2,6 +2,15 @@
 
 Ondine provides comprehensive cost management features to prevent budget overruns and optimize spending on LLM APIs.
 
+<!-- IMAGE_PLACEHOLDER
+title: Cost Control Budget Lifecycle
+type: flowchart
+description: Enterprise Stripe/Vercel design (grid background, left-accent-bar cards, 1px connectors, #0F172A/#64748B typography). Top-to-bottom flow showing budget enforcement during pipeline execution. Top: "Pipeline Start" pill (green). Arrow down to "estimate_cost()" box (blue left-accent) with label "pre-flight cost check". Arrow splits at diamond "Within budget?". Yes arrow → "Execute Pipeline" box (blue). Inside execution box, show a progress bar filling left to right with three threshold markers: 75% (yellow warning icon, label "Warning logged"), 90% (orange alert icon, label "Alert logged"), 100% (red stop icon, label "BudgetExceeded raised"). Arrow from execution to "Cost Report" box (green left-accent) showing breakdown: "tokens: input/output, cost: by stage, savings: from cache hits". No arrow from diamond → "Abort" box (red left-accent, label "adjust budget or optimize before running"). Keep it tall and narrow, generous vertical spacing.
+placement: full-width
+alt_text: Flowchart showing cost control lifecycle: pre-flight estimation, budget check, execution with 75%/90%/100% threshold warnings, and final cost reporting.
+-->
+![Cost Control Budget Lifecycle](guides/images/cost-control-budget-lifecycle.png)
+
 ## Cost Optimization Strategies
 
 ### 1. Multi-Row Batching (100× Speedup) - NEW!

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -18,7 +18,7 @@ description: A flowchart starting with a rounded-rect node "Row processing error
 placement: full-width
 alt_text: Decision flowchart showing error policy routing: SKIP continues with null, FAIL stops the pipeline, RETRY loops with exponential backoff then falls back to skip, USE_DEFAULT substitutes a fixed value.
 -->
-![Error Policy Decision Flowchart](images/error-policy-decision-flowchart.png)
+![Error Policy Decision Flowchart](guides/images/error-policy-decision-flowchart.png)
 
 ## ErrorPolicy
 
@@ -172,7 +172,7 @@ description: A diagram with two nested rounded rectangles representing retry sco
 placement: full-width
 alt_text: Architecture diagram showing two nested retry levels: the inner RetryHandler for transient API errors, and the outer ErrorPolicy RETRY for row-level failures, with non-retryable errors bypassing both.
 -->
-![Two Retry Levels](images/two-retry-levels.png)
+![Two Retry Levels](guides/images/two-retry-levels.png)
 
 One thing to watch: Ondine has two retry mechanisms at different scopes.
 

--- a/docs/guides/execution-modes.md
+++ b/docs/guides/execution-modes.md
@@ -10,6 +10,15 @@ Ondine supports three execution modes optimized for different use cases. Choosin
 | **Async** | High throughput needs | High | High | Medium |
 | **Streaming** | Large datasets (100K+ rows) | Constant | Medium | Medium |
 
+<!-- IMAGE_PLACEHOLDER
+title: Execution Modes Comparison
+type: comparison-table-visual
+description: Enterprise Stripe/Vercel design (grid background, left-accent-bar cards, 1px connectors, #0F172A/#64748B typography). Three-column visual comparison, side by side, same style as routing-strategy-comparison.png. Column 1 "Standard": icon of a single arrow going through boxes sequentially (row→row→row), subtitle "Sequential, simple", mini stats "Memory: loads all rows, Speed: 1x, Use: <50K rows". Green left-accent bar. Column 2 "Async": icon showing multiple arrows fanning out from a semaphore to parallel worker boxes then converging, subtitle "Concurrent requests", mini stats "Memory: loads all rows, Speed: 5-20x, Use: throughput-critical". Blue left-accent bar. Column 3 "Streaming": icon showing a conveyor belt with small chunks moving through, only 1-2 chunks visible at a time, subtitle "Chunk-by-chunk", mini stats "Memory: constant ~50MB, Speed: 1x per chunk, Use: 100K+ rows". Orange left-accent bar. Below all three, a fourth row "Streaming + Async" spanning full width with a combined icon, subtitle "Best of both", stats "Memory: constant, Speed: 5-20x". Purple left-accent bar.
+placement: full-width
+alt_text: Side-by-side comparison of four execution modes: Standard (sequential), Async (concurrent), Streaming (memory-efficient), and Streaming+Async (combined), showing memory usage, speed, and best use cases.
+-->
+![Execution Modes Comparison](guides/images/execution-modes-comparison.png)
+
 ## Standard Execution (Default)
 
 Synchronous, single-threaded processing. The simplest mode.
@@ -119,7 +128,7 @@ async def process_data():
         .with_rate_limit(100)  # Respect API limits
         .build()
     )
-    
+
     result = await pipeline.execute_async()
     print(f"Processed {result.metrics.processed_rows} rows")
     print(f"Time: {result.metrics.elapsed_time:.2f}s")
@@ -208,12 +217,12 @@ all_results = []
 for i, chunk_result in enumerate(pipeline.execute_stream()):
     print(f"Chunk {i+1}: {len(chunk_result.data)} rows, "
           f"Cost: ${chunk_result.costs.total_cost:.4f}")
-    
+
     # Write incrementally
     mode = "w" if i == 0 else "a"
     header = i == 0
     chunk_result.data.to_csv("output.csv", mode=mode, header=header, index=False)
-    
+
     all_results.append(chunk_result)
 
 # Aggregate metrics
@@ -347,4 +356,3 @@ Example: 1K chunk × 10KB/row = ~10MB (constant)
 - [`examples/08_streaming_large_files.py`](../../examples/08_streaming_large_files.py) - Streaming
 - [Cost Control Guide](cost-control.md) - Budget management
 - [API Reference](../api/pipeline.md) - Complete API docs
-

--- a/docs/guides/knowledge-base-rag.md
+++ b/docs/guides/knowledge-base-rag.md
@@ -41,7 +41,7 @@ description: A left-to-right data flow diagram showing the document ingestion pi
 placement: full-width
 alt_text: Data flow diagram showing the RAG ingestion pipeline: documents are loaded, optionally OCR-processed, split into semantic chunks, embedded as dense vectors, and stored in SQLite with both BM25 and vector indexes.
 -->
-![RAG Ingestion Pipeline](images/rag-ingestion-pipeline.png)
+![RAG Ingestion Pipeline](guides/images/rag-ingestion-pipeline.png)
 
 ## Installation
 
@@ -110,7 +110,7 @@ description: A left-to-right sequence diagram showing how with_knowledge_base() 
 placement: full-width
 alt_text: Sequence diagram showing how the pipeline builder retrieves knowledge base context for each row, injects it into the prompt template as _kb_context, sends to the LLM, and optionally evaluates the response.
 -->
-![Pipeline Builder RAG Integration](images/pipeline-builder-rag-integration.png)
+![Pipeline Builder RAG Integration](guides/images/pipeline-builder-rag-integration.png)
 
 ## KnowledgeStore
 
@@ -486,7 +486,7 @@ description: A top-to-bottom flowchart showing the full search path. Start with 
 placement: full-width
 alt_text: Flowchart showing the RAG search flow: user query optionally passes through query transformation, then hybrid search combines BM25 and dense vector retrieval via RRF, optionally reranks with a cross-encoder, and returns top-K results.
 -->
-![RAG Search Flow](images/rag-search-flow.png)
+![RAG Search Flow](guides/images/rag-search-flow.png)
 
 ## OCR Support
 

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -20,7 +20,7 @@ description: A top-to-bottom flowchart showing the full request lifecycle throug
 placement: full-width
 alt_text: Flowchart showing a pipeline request passing through an optional cache check, then into the router which uses the configured strategy to select among multiple providers, with retry logic and a circuit breaker that puts failing providers into cooldown.
 -->
-![Multi-Provider Routing Flow](images/multi-provider-routing-flow.png)
+![Multi-Provider Routing Flow](guides/images/multi-provider-routing-flow.png)
 
 ---
 
@@ -152,7 +152,7 @@ description: A visual grid with four columns, one per key strategy. Each column 
 placement: full-width
 alt_text: Visual comparison of four routing strategies showing how simple-shuffle picks randomly, latency-based picks the fastest provider, usage-based picks the least utilized, and cost-based picks the cheapest.
 -->
-![Routing Strategy Comparison](images/routing-strategy-comparison.png)
+![Routing Strategy Comparison](guides/images/routing-strategy-comparison.png)
 
 ### Simple shuffle (default)
 

--- a/docs/guides/structured-output.md
+++ b/docs/guides/structured-output.md
@@ -24,6 +24,15 @@ ProductInfo(brand="Apple", model="iPhone 15 Pro", price=999.99, condition="new")
 - IDE autocomplete for response fields
 - Validation errors caught early
 
+<!-- IMAGE_PLACEHOLDER
+title: Structured Output Validation Flow
+type: flowchart
+description: Enterprise Stripe/Vercel design (grid background, left-accent-bar cards, 1px connectors, #0F172A/#64748B typography). Top-to-bottom flow with 4 stages. Stage 1: "Raw LLM Response" box (gray left-accent) containing example JSON string '{"brand": "Apple", "model": "iPhone 15 Pro", "price": 999.99}'. Arrow down to Stage 2: "Pydantic Model" box (blue left-accent) showing the class definition with fields and types — brand: str, model: str, price: float, condition: str. Arrow splits into two paths at a diamond labeled "Validation". Left path (green arrow, labeled "Pass"): leads to "Typed Object" box (green left-accent) showing ProductInfo(brand="Apple", ...) with a checkmark icon. Right path (red arrow, labeled "Fail"): leads to "Validation Error" box (red left-accent) showing "price: expected float, got 'expensive'" with an X icon, then a dashed arrow labeled "retry or default" loops back up to Stage 1. Keep the layout clean, generous whitespace.
+placement: full-width
+alt_text: Flowchart showing how LLM raw JSON response passes through Pydantic model validation, producing either a typed object on success or a validation error with retry on failure.
+-->
+![Structured Output Validation Flow](guides/images/structured-output-validation-flow.png)
+
 ## Basic Usage
 
 ### 1. Define Your Pydantic Model
@@ -102,7 +111,7 @@ class Review(BaseModel):
     rating: int = Field(..., ge=1, le=5, description="Rating from 1-5")
     sentiment: str = Field(..., pattern="^(positive|negative|neutral)$")
     summary: str = Field(..., min_length=10, max_length=200)
-    
+
     @validator('rating')
     def rating_must_match_sentiment(cls, v, values):
         sentiment = values.get('sentiment')
@@ -386,11 +395,11 @@ from pydantic import BaseModel, validator
 class Price(BaseModel):
     amount: float
     currency: str = "USD"
-    
+
     @validator('amount')
     def round_price(cls, v):
         return round(v, 2)
-    
+
     @property
     def formatted(self) -> str:
         return f"${self.amount:.2f}"
@@ -497,4 +506,3 @@ logging.basicConfig(level=logging.DEBUG)
 - [Example: 03_structured_output.py](../../examples/03_structured_output.py)
 - [Cost Control](cost-control.md) - Optimize costs
 - [Multi-Column Processing](multi-column.md) - Multiple outputs
-


### PR DESCRIPTION
## Summary

**Bug fix:** Images not rendering on GitBook — all paths were relative to the file (`images/x.png`) but GitBook resolves from docs root. Fixed to `guides/images/x.png` and `getting-started/images/x.png`.

**4 new diagram placeholders** with detailed enterprise-design specs:
- `batch-processing`: multi-row aggregation/disaggregation flow
- `structured-output`: Pydantic validation pass/fail paths
- `execution-modes`: 4-mode side-by-side comparison card
- `cost-control`: budget enforcement lifecycle with 75%/90%/100% thresholds

All placeholders match the existing Stripe/Vercel design language.

## Test plan
- [ ] All 16 existing images now render on GitBook
- [ ] 4 new placeholder `![...]()` tags ready for image generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)