### PR TITLE
fix: image paths broken in GitBook

### DIFF
--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -6,7 +6,7 @@ Understanding Ondine's architecture will help you build more sophisticated pipel
 
 Ondine is built on a layered architecture:
 
-![Ondine Architecture Overview](getting-started/images/architecture-overview.png)
+![Ondine Architecture Overview](images/architecture-overview.png)
 
 ## Key Components
 
@@ -92,7 +92,7 @@ pipeline = (
 
 Stages are composable processing units that form a pipeline:
 
-![Pipeline Stages](getting-started/images/pipeline-stages.png)
+![Pipeline Stages](images/pipeline-stages.png)
 
 **Built-in stages:**
 - `DataLoaderStage`: Load data from files/dataframes

--- a/docs/guides/batch-processing.md
+++ b/docs/guides/batch-processing.md
@@ -16,7 +16,7 @@ description: Left-to-right data flow with enterprise Stripe/Vercel design langua
 placement: full-width
 alt_text: Data flow diagram showing how multi-row batching combines 5 rows into 1 API call through batch aggregation, sends to LLM, then disaggregates the response back into 5 individual results.
 -->
-![Multi-Row Batching Flow](guides/images/multi-row-batching-flow.png)
+![Multi-Row Batching Flow](images/multi-row-batching-flow.png)
 
 ## Quick Start
 

--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -15,7 +15,7 @@ description: A left-to-right flowchart showing the lifecycle of a single pipelin
 placement: full-width
 alt_text: Flowchart showing how a request is hashed, checked against the cache, and either returned immediately on a hit or sent to the LLM API on a miss before the response is stored and returned.
 -->
-![Cache Lookup Request Flow](guides/images/cache-lookup-request-flow.png)
+![Cache Lookup Request Flow](images/cache-lookup-request-flow.png)
 
 ---
 
@@ -174,7 +174,7 @@ description: A side-by-side architecture comparison with two panels. LEFT PANEL 
 placement: full-width
 alt_text: Architecture diagram comparing disk caching with a single process writing to local filesystem versus Redis caching with multiple distributed workers sharing a centralized Redis server with TTL-based expiry.
 -->
-![Disk vs Redis Cache Architecture](guides/images/disk-vs-redis-cache-architecture.png)
+![Disk vs Redis Cache Architecture](images/disk-vs-redis-cache-architecture.png)
 
 **Disk** when you're working locally and want zero-infrastructure caching that sticks around forever.
 

--- a/docs/guides/checkpointing.md
+++ b/docs/guides/checkpointing.md
@@ -20,7 +20,7 @@ description: A horizontal flowchart with five rounded-rect nodes connected by ar
 placement: full-width
 alt_text: Flowchart showing the checkpoint-resume lifecycle: execute, fail at row N, save checkpoint, resume from row N, complete with no duplicate cost.
 -->
-![Checkpoint Resume Lifecycle](guides/images/checkpoint-resume-lifecycle.png)
+![Checkpoint Resume Lifecycle](images/checkpoint-resume-lifecycle.png)
 
 The `StateManager` periodically serialises execution context — last processed row index, accumulated cost, completed responses — into a compressed JSON file:
 
@@ -63,7 +63,7 @@ description: A vertical sequence diagram with two lifelines — "Pipeline Execut
 placement: full-width
 alt_text: Sequence diagram showing the StateManager saving checkpoints to disk at regular intervals as the pipeline executor processes batches of rows.
 -->
-![StateManager Periodic Save Cycle](guides/images/statemanager-periodic-save-cycle.png)
+![StateManager Periodic Save Cycle](images/statemanager-periodic-save-cycle.png)
 
 ### `with_checkpoint_interval(rows: int)`
 

--- a/docs/guides/context-store.md
+++ b/docs/guides/context-store.md
@@ -20,7 +20,7 @@ description: A left-to-right pipeline diagram showing six stages as rounded boxe
 placement: full-width
 alt_text: Data flow diagram of the six-stage anti-hallucination pipeline: evidence priming, LLM inference, grounding verification, contradiction detection, confidence scoring, and storage, with a feedback loop from storage back to evidence priming for subsequent runs.
 -->
-![Anti-Hallucination Pipeline Lifecycle](guides/images/anti-hallucination-pipeline-lifecycle.png)
+![Anti-Hallucination Pipeline Lifecycle](images/anti-hallucination-pipeline-lifecycle.png)
 
 ---
 
@@ -250,7 +250,7 @@ description: A top-to-bottom flowchart showing how grounding verification decide
 placement: full-width
 alt_text: Flowchart showing grounding verification: LLM response is scored against source text via TF-IDF and optional dense embeddings, then compared to the threshold. Grounded responses pass through; ungrounded ones are flagged, retried, or skipped depending on the configured action.
 -->
-![Grounding Verification Flow](guides/images/grounding-verification-flow.png)
+![Grounding Verification Flow](images/grounding-verification-flow.png)
 
 ```python
 # Basic grounding with flag action
@@ -481,7 +481,7 @@ description: A three-column comparison diagram showing the three store backends 
 placement: full-width
 alt_text: Side-by-side comparison of the three context store backends — RustContextStore (persistent, full-featured), ZepContextStore (cloud-hosted with entity extraction but no grounding), and InMemoryContextStore (ephemeral pure-Python fallback) — showing their capabilities, storage model, and search features.
 -->
-![Context Store Backend Comparison](guides/images/context-store-backend-comparison.png)
+![Context Store Backend Comparison](images/context-store-backend-comparison.png)
 
 | Requirement | Backend |
 |---|---|

--- a/docs/guides/cost-control.md
+++ b/docs/guides/cost-control.md
@@ -9,7 +9,7 @@ description: Enterprise Stripe/Vercel design (grid background, left-accent-bar c
 placement: full-width
 alt_text: Flowchart showing cost control lifecycle: pre-flight estimation, budget check, execution with 75%/90%/100% threshold warnings, and final cost reporting.
 -->
-![Cost Control Budget Lifecycle](guides/images/cost-control-budget-lifecycle.png)
+![Cost Control Budget Lifecycle](images/cost-control-budget-lifecycle.png)
 
 ## Cost Optimization Strategies
 

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -18,7 +18,7 @@ description: A flowchart starting with a rounded-rect node "Row processing error
 placement: full-width
 alt_text: Decision flowchart showing error policy routing: SKIP continues with null, FAIL stops the pipeline, RETRY loops with exponential backoff then falls back to skip, USE_DEFAULT substitutes a fixed value.
 -->
-![Error Policy Decision Flowchart](guides/images/error-policy-decision-flowchart.png)
+![Error Policy Decision Flowchart](images/error-policy-decision-flowchart.png)
 
 ## ErrorPolicy
 
@@ -172,7 +172,7 @@ description: A diagram with two nested rounded rectangles representing retry sco
 placement: full-width
 alt_text: Architecture diagram showing two nested retry levels: the inner RetryHandler for transient API errors, and the outer ErrorPolicy RETRY for row-level failures, with non-retryable errors bypassing both.
 -->
-![Two Retry Levels](guides/images/two-retry-levels.png)
+![Two Retry Levels](images/two-retry-levels.png)
 
 One thing to watch: Ondine has two retry mechanisms at different scopes.
 

--- a/docs/guides/execution-modes.md
+++ b/docs/guides/execution-modes.md
@@ -17,7 +17,7 @@ description: Enterprise Stripe/Vercel design (grid background, left-accent-bar c
 placement: full-width
 alt_text: Side-by-side comparison of four execution modes: Standard (sequential), Async (concurrent), Streaming (memory-efficient), and Streaming+Async (combined), showing memory usage, speed, and best use cases.
 -->
-![Execution Modes Comparison](guides/images/execution-modes-comparison.png)
+![Execution Modes Comparison](images/execution-modes-comparison.png)
 
 ## Standard Execution (Default)
 

--- a/docs/guides/knowledge-base-rag.md
+++ b/docs/guides/knowledge-base-rag.md
@@ -41,7 +41,7 @@ description: A left-to-right data flow diagram showing the document ingestion pi
 placement: full-width
 alt_text: Data flow diagram showing the RAG ingestion pipeline: documents are loaded, optionally OCR-processed, split into semantic chunks, embedded as dense vectors, and stored in SQLite with both BM25 and vector indexes.
 -->
-![RAG Ingestion Pipeline](guides/images/rag-ingestion-pipeline.png)
+![RAG Ingestion Pipeline](images/rag-ingestion-pipeline.png)
 
 ## Installation
 
@@ -110,7 +110,7 @@ description: A left-to-right sequence diagram showing how with_knowledge_base() 
 placement: full-width
 alt_text: Sequence diagram showing how the pipeline builder retrieves knowledge base context for each row, injects it into the prompt template as _kb_context, sends to the LLM, and optionally evaluates the response.
 -->
-![Pipeline Builder RAG Integration](guides/images/pipeline-builder-rag-integration.png)
+![Pipeline Builder RAG Integration](images/pipeline-builder-rag-integration.png)
 
 ## KnowledgeStore
 
@@ -486,7 +486,7 @@ description: A top-to-bottom flowchart showing the full search path. Start with 
 placement: full-width
 alt_text: Flowchart showing the RAG search flow: user query optionally passes through query transformation, then hybrid search combines BM25 and dense vector retrieval via RRF, optionally reranks with a cross-encoder, and returns top-K results.
 -->
-![RAG Search Flow](guides/images/rag-search-flow.png)
+![RAG Search Flow](images/rag-search-flow.png)
 
 ## OCR Support
 

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -20,7 +20,7 @@ description: A top-to-bottom flowchart showing the full request lifecycle throug
 placement: full-width
 alt_text: Flowchart showing a pipeline request passing through an optional cache check, then into the router which uses the configured strategy to select among multiple providers, with retry logic and a circuit breaker that puts failing providers into cooldown.
 -->
-![Multi-Provider Routing Flow](guides/images/multi-provider-routing-flow.png)
+![Multi-Provider Routing Flow](images/multi-provider-routing-flow.png)
 
 ---
 
@@ -152,7 +152,7 @@ description: A visual grid with four columns, one per key strategy. Each column 
 placement: full-width
 alt_text: Visual comparison of four routing strategies showing how simple-shuffle picks randomly, latency-based picks the fastest provider, usage-based picks the least utilized, and cost-based picks the cheapest.
 -->
-![Routing Strategy Comparison](guides/images/routing-strategy-comparison.png)
+![Routing Strategy Comparison](images/routing-strategy-comparison.png)
 
 ### Simple shuffle (default)
 

--- a/docs/guides/structured-output.md
+++ b/docs/guides/structured-output.md
@@ -31,7 +31,7 @@ description: Enterprise Stripe/Vercel design (grid background, left-accent-bar c
 placement: full-width
 alt_text: Flowchart showing how LLM raw JSON response passes through Pydantic model validation, producing either a typed object on success or a validation error with retry on failure.
 -->
-![Structured Output Validation Flow](guides/images/structured-output-validation-flow.png)
+![Structured Output Validation Flow](images/structured-output-validation-flow.png)
 
 ## Basic Usage
 


### PR DESCRIPTION
PR #119 broke all images. Reverting to file-relative paths (images/x.png) which is correct for GitBook's markdown resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated image references across multiple guide documentation files to use standardized paths for diagrams and flowcharts, including architecture overviews, batching flows, caching strategies, checkpoint lifecycles, context store configurations, cost control, error handling, execution modes, RAG pipelines, routing flows, and structured output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->