### PR TITLE
chore: update docs URL to docs.ondine.dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/ptimizeroracle/ondine"
 Repository = "https://github.com/ptimizeroracle/ondine"
-Documentation = "https://ptimizeroracle.github.io/ondine"
+Documentation = "https://docs.ondine.dev"
 Issues = "https://github.com/ptimizeroracle/ondine/issues"
 
 [project.optional-dependencies]


### PR DESCRIPTION
Update pyproject.toml Documentation URL from `ptimizeroracle.github.io/ondine` to `https://docs.ondine.dev`.

This fixes the PyPI package page link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)