### PR TITLE
chore: update pyproject.toml homepage to ondine.dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/ptimizeroracle/ondine"
+Homepage = "https://ondine.dev"
 Repository = "https://github.com/ptimizeroracle/ondine"
 Documentation = "https://docs.ondine.dev"
 Issues = "https://github.com/ptimizeroracle/ondine/issues"


### PR DESCRIPTION
## Summary

- `Homepage` URL in `[project.urls]` updated from GitHub repo to `https://ondine.dev`
- This is what shows as the "Homepage" link on the PyPI package page

🤖 Generated with [Claude Code](https://claude.com/claude-code)