### PR TITLE
docs: Retry-After, distributed rate limiting, crash-safe resume

### DIFF
--- a/docs/guides/checkpointing.md
+++ b/docs/guides/checkpointing.md
@@ -22,11 +22,20 @@ alt_text: Flowchart showing the checkpoint-resume lifecycle: execute, fail at ro
 -->
 ![Checkpoint Resume Lifecycle](images/checkpoint-resume-lifecycle.png)
 
-The `StateManager` periodically serialises execution context (last processed row index, accumulated cost, completed responses) into a compressed JSON file:
+The `StateManager` periodically serialises execution context (last processed row index, accumulated cost, aggregate counters) into a compressed JSON file, and every completed LLM response streams row-by-row into a SQLite database next to it:
 
 ```
-.checkpoints/checkpoint_<session-uuid>.json.gz
+.checkpoints/checkpoint_<session-uuid>.json.gz   # counters, small
+.checkpoints/responses.db                         # one row per completed LLM call
 ```
+
+**Why two files?** The JSON blob used to also carry every completed response inline — that rewrote a ~100MB file every checkpoint window (O(N²) IO on long runs) and could be truncated mid-write by a `kill -9`. The SQLite file uses WAL mode and appends one row per response atomically, so:
+
+- A hard kill between any two rows leaves **every completed row intact**. No partial writes.
+- Checkpoint windows stay small — only counters are rewritten.
+- Resume reads responses back in `row_index` order regardless of worker completion order.
+
+The `responses.db` is managed for you. It's cleared automatically on successful completion (unless you disable cleanup) and reattached by path when you resume.
 
 When execution fails, the logs hand you a ready-to-paste resume call:
 

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -163,6 +163,12 @@ With `retry_delay=1.0` and `max_retries=5`:
 
 Cap is 60 seconds no matter the multiplier.
 
+### Honouring `Retry-After`
+
+When a provider returns HTTP 429 with a `Retry-After` header (either a seconds count or an HTTP date), Ondine parses it and waits **at least** that long before the next attempt. This is automatic — no configuration needed. The exponential backoff above is still applied on top, so you'll never sleep *less* than the server asked for.
+
+What this buys you: on shared API keys (OpenAI/Anthropic tier limits, Groq free tier), the server often tells you the exact moment the window reopens. Honouring it avoids the usual "hammer until unblocked" pattern that wastes retry budget and triggers stricter throttling.
+
 ## Two Levels of Retry
 
 <!-- IMAGE_PLACEHOLDER
@@ -321,6 +327,31 @@ pipeline = (
 
 result = pipeline.execute()
 ```
+
+## Distributed Rate Limiting (Redis)
+
+`with_rate_limit(rpm)` gives you an in-process token bucket. That's enough for a single pipeline but breaks down when several jobs share one API key — each job runs its own bucket, so N parallel workers allow N×rpm against the provider.
+
+Pass a `redis_url` and a `scope` to share one bucket across every worker pointed at it:
+
+```python
+pipeline = (
+    PipelineBuilder.create()
+    .from_dataframe(df, input_columns=["text"], output_columns=["result"])
+    .with_prompt("Process: {text}")
+    .with_llm(provider="openai", model="gpt-4o-mini")
+    .with_rate_limit(
+        100,
+        redis_url="redis://localhost:6379/0",
+        scope="openai:gpt-4o-mini",
+    )
+    .build()
+)
+```
+
+Workers that must share a budget use the **same** `scope`. Typical format: `"provider:model"` or `"provider:model:tier"`. Two jobs with different scopes get independent buckets even on the same Redis.
+
+**Fallback behaviour.** If Redis becomes unreachable mid-run, the limiter automatically falls back to an in-process bucket at the same `rpm`. A Redis outage cannot deadlock the pipeline — it just loses the cross-worker coordination until Redis returns.
 
 ## Non-Retryable Errors
 

--- a/ondine/api/pipeline_builder.py
+++ b/ondine/api/pipeline_builder.py
@@ -701,7 +701,13 @@ class PipelineBuilder:
         self._processing_spec.cleanup_on_success = enabled
         return self
 
-    def with_rate_limit(self, rpm: int) -> PipelineBuilder:
+    def with_rate_limit(
+        self,
+        rpm: int,
+        *,
+        redis_url: str | None = None,
+        scope: str | None = None,
+    ) -> PipelineBuilder:
         """
         Configure rate limiting.
 
@@ -710,26 +716,43 @@ class PipelineBuilder:
 
         Args:
             rpm: Requests per minute (typical: 20-60 for free tiers, 100+ for paid)
+            redis_url: Optional ``redis://host:port/db`` URL. When set, workers
+                sharing the same Redis + ``scope`` share one token bucket —
+                the canonical solution when multiple Ondine jobs target the
+                same provider API key. Falls back to an in-process limiter
+                at the same ``rpm`` if Redis is unreachable.
+            scope: Bucket scope for the distributed limiter. Workers that
+                must share a budget use the same scope (e.g.
+                ``"openai:gpt-4o"`` or ``"anthropic:sonnet:tier2"``).
+                Ignored when ``redis_url`` is not set.
 
         Returns:
             Self for chaining
 
         Example:
             ```python
-            # OpenAI free tier (60 RPM limit)
+            # Single-process: in-memory token bucket
             builder.with_rate_limit(50)
 
-            # Groq free tier (30 RPM limit)
-            builder.with_rate_limit(25)
-
-            # Paid tier with high limits
-            builder.with_rate_limit(100)
+            # Multi-process: one shared bucket across every worker
+            # pointed at the same Redis + scope
+            builder.with_rate_limit(
+                100,
+                redis_url="redis://localhost:6379/0",
+                scope="openai:gpt-4o-mini",
+            )
             ```
 
         Note:
-            Rate limiting is applied per pipeline execution, not globally.
+            Without ``redis_url``, rate limiting is per-process. Each
+            pipeline instance gets its own token bucket, so N parallel
+            jobs effectively allow N×rpm against your provider.
         """
         self._processing_spec.rate_limit_rpm = rpm
+        if redis_url is not None:
+            self._processing_spec.rate_limit_redis_url = redis_url
+        if scope is not None:
+            self._processing_spec.rate_limit_scope = scope
         return self
 
     def with_max_retries(self, retries: int) -> PipelineBuilder:


### PR DESCRIPTION
## Summary
- Document the automatic **Retry-After** header honouring shipped in A2 ([#141](https://github.com/ptimizeroracle/ondine/pull/141))
- Document the new **distributed Redis rate limiter** shipped in A3 ([#142](https://github.com/ptimizeroracle/ondine/pull/142)) and extend `PipelineBuilder.with_rate_limit(rpm, *, redis_url, scope)` so enabling it doesn't require reaching into `ProcessingSpec`
- Document the crash-atomic **SQLite response cache** shipped in A4 ([#144](https://github.com/ptimizeroracle/ondine/pull/144)) — the new `responses.db` next to the checkpoint, why it exists, what you see on disk

## Test plan
- [x] pre-commit hooks pass locally (ruff, format, bandit, unit tests)
- [ ] CI green
- [ ] Review rendered pages for tone/fit

🤖 Generated with [Claude Code](https://claude.com/claude-code)