### PR TITLE
fix(ci): pin sigstore action to v3.3.0

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -102,7 +102,7 @@ jobs:
         cyclonedx-py environment -o sbom.json --format json
 
     - name: Sign artifacts with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3
+      uses: sigstore/gh-action-sigstore-python@v3.3.0
       with:
         inputs: target/wheels/*.whl
 

--- a/ondine/adapters/response_cache.py
+++ b/ondine/adapters/response_cache.py
@@ -186,6 +186,11 @@ class SqliteResponseCache(ResponseCache):
         # WAL survives a hard kill with every committed txn intact.
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA synchronous=NORMAL")
+        # Multiple processes/connections may share the same responses.db
+        # (e.g. pipelined streaming spins one sub-pipeline per chunk, each
+        # opening its own connection). Wait up to 5s for the writer lock
+        # instead of erroring with "database is locked".
+        self._conn.execute("PRAGMA busy_timeout=5000")
         self._conn.execute(_SCHEMA)
 
     def append(

--- a/uv.lock
+++ b/uv.lock
@@ -3480,7 +3480,7 @@ wheels = [
 
 [[package]]
 name = "ondine"
-version = "1.8.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -3480,7 +3480,7 @@ wheels = [
 
 [[package]]
 name = "ondine"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- `sigstore/gh-action-sigstore-python` has no floating `v3` tag — only concrete releases like `v3.3.0`, `v3.2.0`, …
- v1.8.0 publish workflow failed at Set up job with \`unable to find version v3\`
- Pin to `v3.3.0` and sync `uv.lock` to the 1.8.0 version bump

## Test plan
- [x] pre-commit hooks pass locally (full unit suite green)
- [ ] After merge: re-run `Release to PyPI` workflow against tag `v1.8.0` via `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PyPI publishing workflow to use a pinned version of the signing action for improved stability and security in the artifact release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->