### PR TITLE
feat(api): wire with_adaptive_concurrency() end-to-end

### DIFF
--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -169,6 +169,39 @@ When a provider returns HTTP 429 with a `Retry-After` header (either a seconds c
 
 What this buys you: on shared API keys (OpenAI/Anthropic tier limits, Groq free tier), the server often tells you the exact moment the window reopens. Honouring it avoids the usual "hammer until unblocked" pattern that wastes retry budget and triggers stricter throttling.
 
+### Adaptive Concurrency
+
+`with_concurrency(N)` sets a fixed in-flight cap. That's the right default — simple, predictable, and fine when you already know the provider's rate limit. But it's brittle when the limit is opaque, changes during a job (tier promotion, shared-key contention), or differs per model.
+
+`with_adaptive_concurrency()` opts in to a [Gradient2](https://github.com/Netflix/concurrency-limits)-style controller that probes the real ceiling:
+
+```python
+pipeline = (
+    PipelineBuilder.create()
+    .from_csv("prompts.csv", input_columns=["text"], output_columns=["label"])
+    .with_prompt("Classify: {text}")
+    .with_llm(model="openai/gpt-4o-mini")
+    .with_concurrency(20)              # upper bound
+    .with_adaptive_concurrency()       # shrink on 429 / RTT inflation, grow on saturation
+    .build()
+)
+```
+
+Semantics:
+
+* The effective in-flight cap starts at `with_concurrency(...)` and is bounded by it — adaptive never goes *above* your ceiling.
+* On 429 responses or RTT inflation vs the measured baseline, the cap shrinks.
+* On sustained saturation (in-flight == cap) with near-baseline RTT, the cap grows.
+* Floor is 1; the pipeline never stalls.
+
+When to enable:
+* Running against a provider whose rate limit you don't know precisely.
+* Sharing an API key with other jobs (adaptive also cooperates well with `rate_limit_redis_url=...` below).
+* You'd rather over-provision the ceiling and let the controller find the sweet spot than tune `with_concurrency(...)` by hand.
+
+When to leave off (the default):
+* You've measured the provider and a fixed cap is working. Adaptive adds a small CPU cost per request and slight latency variance from probing. Not worth it if you don't need it.
+
 ## Two Levels of Retry
 
 <!-- IMAGE_PLACEHOLDER

--- a/ondine/api/pipeline.py
+++ b/ondine/api/pipeline.py
@@ -719,6 +719,7 @@ class Pipeline:
             if specs.metadata
             else None,
             budget_controller=budget_controller,
+            adaptive_concurrency=specs.processing.adaptive_concurrency,
         )
         # Stage 3: Execute LLM invocation
         response_batches = (

--- a/ondine/api/pipeline_builder.py
+++ b/ondine/api/pipeline_builder.py
@@ -669,6 +669,36 @@ class PipelineBuilder:
         self._processing_spec.concurrency = threads
         return self
 
+    def with_adaptive_concurrency(self, enabled: bool = True) -> PipelineBuilder:
+        """Opt-in adaptive in-flight cap (Gradient2 algorithm).
+
+        When enabled, the effective concurrency shrinks on 429 / RTT
+        inflation and grows on saturation with near-baseline RTT. The
+        ceiling is ``with_concurrency(...)``; the floor is 1. Use this
+        when the provider's rate limits are opaque or variable and
+        you'd rather let Ondine probe for the sweet spot than pick
+        a fixed number.
+
+        Default is off — behaviour is byte-identical to prior versions.
+
+        Args:
+            enabled: ``True`` to turn on, ``False`` to turn off. Passing
+                ``False`` is useful to undo an earlier call on the same
+                builder.
+
+        Returns:
+            Self for chaining.
+
+        Example:
+            ```python
+            # Let Ondine find the right concurrency under a flaky
+            # third-party API — upper bound still 20.
+            builder.with_concurrency(20).with_adaptive_concurrency()
+            ```
+        """
+        self._processing_spec.adaptive_concurrency = enabled
+        return self
+
     def with_checkpoint_interval(self, rows: int) -> PipelineBuilder:
         """
         Configure checkpoint frequency.

--- a/ondine/core/specifications.py
+++ b/ondine/core/specifications.py
@@ -444,6 +444,17 @@ class ProcessingSpec(BaseModel):
             "format is 'provider:model' or 'provider:model:tier'."
         ),
     )
+    adaptive_concurrency: bool = Field(
+        default=False,
+        description=(
+            "Opt-in Gradient2-based adaptive concurrency cap. When "
+            "enabled, the effective in-flight limit shrinks on 429/RTT "
+            "inflation and grows on saturation with near-baseline RTT, "
+            "bounded above by ``concurrency`` and below by 1. Default "
+            "is off — fixed semaphore behaviour, byte-identical to "
+            "prior versions."
+        ),
+    )
     max_budget: Decimal | None = Field(
         default=None, gt=0, description="Maximum budget in USD"
     )

--- a/tests/e2e/test_builder_adaptive_real_api.py
+++ b/tests/e2e/test_builder_adaptive_real_api.py
@@ -1,0 +1,56 @@
+"""Real-API smoke test for ``PipelineBuilder.with_adaptive_concurrency``.
+
+Gated by ``OPENAI_API_KEY`` — skipped in CI unless the secret is
+configured, so local and offline runs stay clean. Purpose: prove
+that toggling the builder method actually runs the pipeline
+successfully against a real provider. It does NOT try to induce
+429s — the existing ``test_a2_real_http_server.py`` covers 429
+behaviour under a local fake server.
+
+What this catches that the unit tests don't:
+* Wiring regressions that only surface when LiteLLM is actually
+  invoked (e.g. if ``adaptive_concurrency=True`` causes the real
+  async path to dead-lock, the unit test's monkey-patched init
+  would not notice).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pandas as pd
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not set — skipping real-API smoke test",
+)
+
+
+def test_adaptive_concurrency_real_openai_smoke():
+    """Run a two-row pipeline against real OpenAI with adaptive on.
+
+    Passes if the pipeline completes successfully. The assertion is
+    intentionally weak — the provider won't 429 us on two calls, so
+    the only invariant we can check is that enabling adaptive does
+    not break the happy path.
+    """
+    from ondine.api.pipeline_builder import PipelineBuilder
+
+    df = pd.DataFrame({"text": ["apple", "banana"]})
+
+    pipeline = (
+        PipelineBuilder.create()
+        .from_dataframe(df, input_columns=["text"], output_columns=["category"])
+        .with_prompt("Reply with exactly one word: the category of '{text}'.")
+        .with_llm(model="openai/gpt-4o-mini")
+        .with_concurrency(2)
+        .with_adaptive_concurrency()
+        .with_progress_mode("none")
+        .build()
+    )
+
+    result = pipeline.execute()
+
+    assert result.success, f"pipeline failed: {result}"
+    assert len(result.data) == 2

--- a/tests/unit/test_builder_adaptive_concurrency.py
+++ b/tests/unit/test_builder_adaptive_concurrency.py
@@ -1,0 +1,104 @@
+"""Tests for ``PipelineBuilder.with_adaptive_concurrency`` wiring.
+
+Before this change, ``LLMInvocationStage(adaptive_concurrency=True)``
+existed but was unreachable — nothing passed the flag from specs to
+the stage. These tests lock in the end-to-end plumb so the feature
+stays reachable:
+
+* ``ProcessingSpec.adaptive_concurrency`` is part of the spec shape.
+* ``PipelineBuilder.with_adaptive_concurrency()`` flips it.
+* The constructed ``LLMInvocationStage`` sees the flag.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from ondine.api.pipeline_builder import PipelineBuilder
+from ondine.core.specifications import ProcessingSpec
+
+
+class TestProcessingSpecHasField:
+    """The spec is the contract between builder and pipeline — if the
+    field disappears, everything silently degrades."""
+
+    def test_default_is_false(self):
+        spec = ProcessingSpec()
+        assert spec.adaptive_concurrency is False
+
+    def test_can_be_set_true(self):
+        spec = ProcessingSpec(adaptive_concurrency=True)
+        assert spec.adaptive_concurrency is True
+
+
+class TestBuilderMethod:
+    """Public API surface — users call this to opt in."""
+
+    def _base_builder(self) -> PipelineBuilder:
+        df = pd.DataFrame({"text": ["hello"]})
+        return (
+            PipelineBuilder.create()
+            .from_dataframe(df, input_columns=["text"], output_columns=["out"])
+            .with_prompt("Classify: {text}")
+            .with_llm(model="mock", provider="openai")
+        )
+
+    def test_with_adaptive_concurrency_sets_spec_flag(self):
+        builder = self._base_builder().with_adaptive_concurrency()
+        pipeline = builder.build()
+        assert pipeline.specifications.processing.adaptive_concurrency is True
+
+    def test_default_off_when_builder_method_not_called(self):
+        builder = self._base_builder()
+        pipeline = builder.build()
+        assert pipeline.specifications.processing.adaptive_concurrency is False
+
+    def test_can_disable_explicitly(self):
+        builder = self._base_builder().with_adaptive_concurrency(False)
+        pipeline = builder.build()
+        assert pipeline.specifications.processing.adaptive_concurrency is False
+
+
+class TestStageReceivesFlag:
+    """Plumbing regression — the flag must flow from spec into the
+    stage that actually uses it. Verifies by capturing the kwargs
+    passed to ``LLMInvocationStage`` during pipeline execution."""
+
+    def test_pipeline_forwards_adaptive_flag_to_llm_stage(self, monkeypatch):
+        import ondine.api.pipeline as pipeline_mod
+
+        captured: dict = {}
+        real_init = pipeline_mod.LLMInvocationStage.__init__
+
+        def capturing_init(self, *args, **kwargs):  # noqa: ANN001
+            captured.update(kwargs)
+            # Stop the init chain; we only need the kwargs snapshot.
+            raise _StopExecutionError
+
+        monkeypatch.setattr(pipeline_mod.LLMInvocationStage, "__init__", capturing_init)
+
+        df = pd.DataFrame({"text": ["hello"]})
+        pipeline = (
+            PipelineBuilder.create()
+            .from_dataframe(df, input_columns=["text"], output_columns=["out"])
+            .with_prompt("Classify: {text}")
+            .with_llm(model="mock", provider="openai")
+            .with_adaptive_concurrency()
+            .build()
+        )
+
+        try:
+            pipeline.execute()
+        except _StopExecutionError:
+            pass
+
+        # Restore for any other tests that share the class — monkeypatch
+        # auto-restores at teardown, but be explicit about intent.
+        pipeline_mod.LLMInvocationStage.__init__ = real_init
+
+        assert captured.get("adaptive_concurrency") is True
+
+
+class _StopExecutionError(Exception):
+    """Sentinel to short-circuit pipeline.execute() once we've
+    captured the kwargs we care about."""

--- a/uv.lock
+++ b/uv.lock
@@ -3480,7 +3480,7 @@ wheels = [
 
 [[package]]
 name = "ondine"
-version = "1.7.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Adds `PipelineBuilder.with_adaptive_concurrency(enabled=True)` — closes a reachability gap from A2 (PR #141), where `LLMInvocationStage(adaptive_concurrency=True)` existed as a kwarg but nothing in the builder/specs path passed it through.
- Adds `ProcessingSpec.adaptive_concurrency: bool = False` and threads it through `pipeline.py:_execute_stages` → `LLMInvocationStage` → `ConcurrencyController`.
- TDD: unit tests lock in spec → builder → stage plumb. Gated real-API smoke test (skipped when `OPENAI_API_KEY` unset) catches wiring regressions that only surface when LiteLLM is actually invoked.
- Docs: new "Adaptive Concurrency" section in `docs/guides/error-handling.md` covering semantics, when to enable, when to leave off.

## Test plan
- [x] `uv run pytest tests/unit/test_builder_adaptive_concurrency.py` — 6/6 pass
- [x] `uv run pytest tests/unit/test_pipeline_builder*.py tests/unit/test_pipeline_builder_custom_client.py` — 39/39 pass
- [x] `tests/e2e/test_builder_adaptive_real_api.py` skips cleanly without API key
- [ ] CI green
- [ ] Optional: maintainer with `OPENAI_API_KEY` runs the gated smoke test locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced adaptive concurrency control as an alternative to fixed request limits. The adaptive cap automatically adjusts based on server feedback and response times, with a configurable floor and ceiling.

* **Documentation**
  * Added comprehensive guide covering adaptive concurrency behavior, usage examples, and recommendations for when to enable this feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->