### PR TITLE
fix(ci): drop unsupported --format flag from cyclonedx-py

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Generate SBOM
       run: |
         pip install cyclonedx-bom
-        cyclonedx-py environment -o sbom.json --format json
+        cyclonedx-py environment -o sbom.json
 
     - name: Sign artifacts with Sigstore
       uses: sigstore/gh-action-sigstore-python@v3.3.0

--- a/uv.lock
+++ b/uv.lock
@@ -3480,7 +3480,7 @@ wheels = [
 
 [[package]]
 name = "ondine"
-version = "1.8.1"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
`cyclonedx-py` no longer accepts `--format json` — JSON is the default. The v1.9.0 PyPI publish failed at the SBOM step with `unrecognized arguments: --format`. Drop the flag so the publish workflow runs on current cyclonedx-bom.

## Test plan
- [x] Local `cyclonedx-py environment -o sbom.json` produces valid JSON without the flag
- [ ] Re-trigger publish-pypi for v1.9.0 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SBOM generation configuration in the publishing workflow for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->