### PR TITLE
fix(ci): publish wheels for all platforms + TestPyPI smoke gate

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,7 +3,7 @@ name: Release to PyPI
 # ──────────────────────────────────────────────────────────────────────────
 # Publishing pipeline:
 #   resolve-tag → build-sdist  ┐
-#                              ├─► verify-matrix-complete (20 wheels gate)
+#                              ├─► verify-matrix-complete (16 wheels gate)
 #                 build-wheels ┘                 ↓
 #                                          publish-testpypi
 #                                                ↓
@@ -92,7 +92,7 @@ jobs:
           if-no-files-found: error
 
   # ────────────────────────────────────────────────────────────────────
-  # 3. Binary wheels — 5 platforms × 4 Python versions = 20 wheels
+  # 3. Binary wheels — 4 platforms × 4 Python = 16 wheels (Mac is universal2)
   # ────────────────────────────────────────────────────────────────────
   build-wheels:
     needs: resolve-tag
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, windows-latest]
         python: ["3.10", "3.11", "3.12", "3.13"]
         include:
           - os: ubuntu-latest
@@ -110,10 +110,8 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             manylinux: auto
-          - os: macos-13
-            target: x86_64-apple-darwin
           - os: macos-14
-            target: aarch64-apple-darwin
+            target: universal2-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
     steps:
@@ -159,7 +157,7 @@ jobs:
   # ────────────────────────────────────────────────────────────────────
   verify-matrix-complete:
     needs: [build-sdist, build-wheels]
-    name: Verify 20 wheels + 1 sdist
+    name: Verify 16 wheels + 1 sdist
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -178,17 +176,17 @@ jobs:
           echo "────────────────────────────────────────"
           ls -la dist/
           echo "────────────────────────────────────────"
-          echo "Wheels: $WHEEL_COUNT  (expected 20)"
+          echo "Wheels: $WHEEL_COUNT  (expected 16)"
           echo "Sdist:  $SDIST_COUNT  (expected 1)"
-          if [ "$WHEEL_COUNT" -ne 20 ]; then
-            echo "::error::Matrix incomplete — expected exactly 20 wheels, got $WHEEL_COUNT"
+          if [ "$WHEEL_COUNT" -ne 16 ]; then
+            echo "::error::Matrix incomplete — expected exactly 16 wheels, got $WHEEL_COUNT"
             exit 1
           fi
           if [ "$SDIST_COUNT" -ne 1 ]; then
             echo "::error::Expected 1 sdist, got $SDIST_COUNT"
             exit 1
           fi
-          echo "✅ 20 wheels + 1 sdist present"
+          echo "✅ 16 wheels + 1 sdist present"
 
   # ────────────────────────────────────────────────────────────────────
   # 5. Upload to TestPyPI as smoke-test target
@@ -230,10 +228,11 @@ jobs:
       matrix:
         include:
           - { os: macos-14,         python: "3.10" }
+          - { os: macos-14,         python: "3.12" }
           - { os: macos-14,         python: "3.13" }
-          - { os: macos-13,         python: "3.11" }
           - { os: windows-latest,   python: "3.10" }
           - { os: windows-latest,   python: "3.13" }
+          - { os: ubuntu-24.04-arm, python: "3.11" }
           - { os: ubuntu-24.04-arm, python: "3.12" }
     steps:
       - uses: actions/setup-python@v5

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -145,7 +145,7 @@ jobs:
         working-directory: ${{ runner.temp }}
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --find-links ${{ github.workspace }}/dist "ondine==${{ needs.resolve-tag.outputs.version }}"
+          python -m pip install --find-links "$GITHUB_WORKSPACE/dist" "ondine==${{ needs.resolve-tag.outputs.version }}"
           python -c "
           from ondine._engine import EvidenceDB
           db = EvidenceDB(':memory:')

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -202,11 +202,9 @@ jobs:
           pattern: wheel-*
           path: dist
           merge-multiple: true
-      - uses: actions/download-artifact@v4
-        with:
-          name: sdist
-          path: dist
-      - name: Upload to TestPyPI
+      # sdist intentionally skipped: TestPyPI smoke-test uses --only-binary,
+      # so only wheels matter. Prod publish uploads both.
+      - name: Upload wheels to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -137,7 +137,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --no-index --find-links dist "ondine==${{ needs.resolve-tag.outputs.version }}"
+          python -m pip install --find-links dist "ondine==${{ needs.resolve-tag.outputs.version }}"
           python -c "
           from ondine._engine import EvidenceDB
           db = EvidenceDB(':memory:')

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -143,13 +143,15 @@ jobs:
       - name: Self-test wheel — Rust extension imports
         shell: bash
         working-directory: ${{ runner.temp }}
+        env:
+          PYTHONIOENCODING: utf-8
         run: |
           python -m pip install --upgrade pip
           python -m pip install --find-links "$GITHUB_WORKSPACE/dist" "ondine==${{ needs.resolve-tag.outputs.version }}"
           python -c "
           from ondine._engine import EvidenceDB
           db = EvidenceDB(':memory:')
-          print('✅ ondine._engine loads on ${{ matrix.os }} py${{ matrix.python }}')
+          print('OK ondine._engine loads on ${{ matrix.os }} py${{ matrix.python }}')
           "
 
   # ────────────────────────────────────────────────────────────────────
@@ -260,11 +262,13 @@ jobs:
 
       - name: Verify Rust extension loads (regression gate)
         shell: bash
+        env:
+          PYTHONIOENCODING: utf-8
         run: |
           python -c "
           from ondine._engine import EvidenceDB
           db = EvidenceDB(':memory:')
-          print('✅ ${{ matrix.os }} py${{ matrix.python }}: wheel installed + Rust extension works')
+          print('OK ${{ matrix.os }} py${{ matrix.python }}: wheel installed + Rust extension works')
           "
 
   # ────────────────────────────────────────────────────────────────────

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -133,23 +133,31 @@ jobs:
           manylinux: ${{ matrix.manylinux || '' }}
           sccache: true
 
-      - name: Self-test wheel — Rust extension imports
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --find-links dist "ondine==${{ needs.resolve-tag.outputs.version }}"
-          python -c "
-          from ondine._engine import EvidenceDB
-          db = EvidenceDB(':memory:')
-          print('✅ ondine._engine loads on ${{ matrix.os }} py${{ matrix.python }}')
-          "
-
       - uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ matrix.os }}-py${{ matrix.python }}
           path: dist/*.whl
           retention-days: 90
           if-no-files-found: error
+
+      - name: Inspect wheel contents
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m zipfile -l dist/*.whl | head -50
+          echo "────────────────────────────────────────"
+          echo "Looking for _engine extension:"
+          python -m zipfile -l dist/*.whl | grep -i "_engine" || echo "::warning::no _engine file found in wheel"
+
+      - name: Self-test wheel — Rust extension imports
+        shell: bash
+        run: |
+          python -m pip install --find-links dist "ondine==${{ needs.resolve-tag.outputs.version }}"
+          python -c "
+          from ondine._engine import EvidenceDB
+          db = EvidenceDB(':memory:')
+          print('✅ ondine._engine loads on ${{ matrix.os }} py${{ matrix.python }}')
+          "
 
   # ────────────────────────────────────────────────────────────────────
   # 4. Matrix completeness gate — block if any wheel silently dropped

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -151,8 +151,9 @@ jobs:
 
       - name: Self-test wheel — Rust extension imports
         shell: bash
+        working-directory: ${{ runner.temp }}
         run: |
-          python -m pip install --find-links dist "ondine==${{ needs.resolve-tag.outputs.version }}"
+          python -m pip install --find-links ${{ github.workspace }}/dist "ondine==${{ needs.resolve-tag.outputs.version }}"
           python -c "
           from ondine._engine import EvidenceDB
           db = EvidenceDB(':memory:')

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -295,12 +295,21 @@ jobs:
         with:
           inputs: ./dist/*.whl ./dist/*.tar.gz
 
+      - name: Move sigstore bundles out of upload dir
+        run: |
+          mkdir -p signatures
+          mv dist/*.sigstore.json signatures/ || true
+          ls -la dist/ signatures/
+
       - name: Upload to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: dist/
           skip-existing: true
+
+      - name: Restore sigstore bundles for archive
+        run: mv signatures/*.sigstore.json dist/ || true
 
       - name: Archive signed release
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -140,19 +140,11 @@ jobs:
           retention-days: 90
           if-no-files-found: error
 
-      - name: Inspect wheel contents
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          python -m zipfile -l dist/*.whl | head -50
-          echo "────────────────────────────────────────"
-          echo "Looking for _engine extension:"
-          python -m zipfile -l dist/*.whl | grep -i "_engine" || echo "::warning::no _engine file found in wheel"
-
       - name: Self-test wheel — Rust extension imports
         shell: bash
         working-directory: ${{ runner.temp }}
         run: |
+          python -m pip install --upgrade pip
           python -m pip install --find-links ${{ github.workspace }}/dist "ondine==${{ needs.resolve-tag.outputs.version }}"
           python -c "
           from ondine._engine import EvidenceDB

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -207,12 +207,12 @@ jobs:
           name: sdist
           path: dist
       - name: Upload to TestPyPI
-        uses: PyO3/maturin-action@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          command: upload
-          args: --repository-url https://test.pypi.org/legacy/ --skip-existing dist/*
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          packages-dir: dist/
+          skip-existing: true
 
   # ────────────────────────────────────────────────────────────────────
   # 6. Smoke test — install from TestPyPI on platforms that were broken
@@ -298,12 +298,11 @@ jobs:
           inputs: ./dist/*.whl ./dist/*.tar.gz
 
       - name: Upload to PyPI
-        uses: PyO3/maturin-action@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          command: upload
-          args: --skip-existing dist/*.whl dist/*.tar.gz
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: dist/
+          skip-existing: true
 
       - name: Archive signed release
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,12 +1,30 @@
 name: Release to PyPI
 
+# ──────────────────────────────────────────────────────────────────────────
+# Publishing pipeline:
+#   resolve-tag → build-sdist  ┐
+#                              ├─► verify-matrix-complete (20 wheels gate)
+#                 build-wheels ┘                 ↓
+#                                          publish-testpypi
+#                                                ↓
+#                                          smoke-test (6 runners, fresh pip install)
+#                                                ↓
+#                                          publish-prod (Sigstore-signed)
+#
+# The smoke-test job installs from TestPyPI on macOS arm64, macOS x86_64,
+# Windows, and Linux arm64 WITHOUT any Rust toolchain present. If any
+# wheel is missing, pip tries to build from sdist, fails, and blocks the
+# prod publish. This catches the regression class from v1.7.0-v1.9.1 where
+# only Linux x86_64 Python 3.11 wheels were published.
+# ──────────────────────────────────────────────────────────────────────────
+
 on:
   release:
     types: [published]
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Existing release tag to publish (for example: v1.4.0)"
+        description: "Existing release tag to publish (e.g. v1.10.0)"
         required: true
         type: string
 
@@ -16,113 +34,276 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write  # Required for Sigstore signing
+  id-token: write  # Sigstore signing
 
 jobs:
-  build-and-publish:
-    name: Build and publish to PyPI
+
+  # ────────────────────────────────────────────────────────────────────
+  # 1. Resolve release tag and verify it matches pyproject.toml version
+  # ────────────────────────────────────────────────────────────────────
+  resolve-tag:
+    name: Resolve release tag
     runs-on: ubuntu-latest
-    environment: Ondine  # Use the Ondine environment with PYPI_API_TOKEN
-
+    outputs:
+      tag: ${{ steps.r.outputs.tag }}
+      version: ${{ steps.r.outputs.version }}
     steps:
-    - name: Checkout release ref
-      if: github.event_name == 'release'
-      uses: actions/checkout@v6
-      with:
-        ref: ${{ github.event.release.tag_name }}
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
+      - id: r
+        shell: bash
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.release_tag }}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            echo "::error::Expected SemVer tag starting with v, got: $TAG"
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          PACKAGE_VERSION=$(grep '^version = ' pyproject.toml | cut -d'"' -f2)
+          if [ "$VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "::error::Tag version ($VERSION) != pyproject.toml version ($PACKAGE_VERSION)"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "✅ Tag $TAG / version $VERSION"
 
-    - name: Checkout manual release tag
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/checkout@v6
-      with:
-        ref: ${{ inputs.release_tag }}
+  # ────────────────────────────────────────────────────────────────────
+  # 2. Source distribution (one tarball)
+  # ────────────────────────────────────────────────────────────────────
+  build-sdist:
+    needs: resolve-tag
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          retention-days: 90
+          if-no-files-found: error
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
+  # ────────────────────────────────────────────────────────────────────
+  # 3. Binary wheels — 5 platforms × 4 Python versions = 20 wheels
+  # ────────────────────────────────────────────────────────────────────
+  build-wheels:
+    needs: resolve-tag
+    name: Wheel ${{ matrix.os }} py${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14, windows-latest]
+        python: ["3.10", "3.11", "3.12", "3.13"]
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            manylinux: auto
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            manylinux: auto
+          - os: macos-13
+            target: x86_64-apple-darwin
+          - os: macos-14
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
 
-    - name: Set up Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
 
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
+      - name: Build wheel via maturin
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist -i python${{ matrix.python }}
+          manylinux: ${{ matrix.manylinux || '' }}
+          sccache: true
 
-    - name: Install uv and maturin
-      run: |
-        pip install uv maturin
+      - name: Self-test wheel — Rust extension imports
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --no-index --find-links dist "ondine==${{ needs.resolve-tag.outputs.version }}"
+          python -c "
+          from ondine._engine import EvidenceDB
+          db = EvidenceDB(':memory:')
+          print('✅ ondine._engine loads on ${{ matrix.os }} py${{ matrix.python }}')
+          "
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v7
-      with:
-        enable-cache: true
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.os }}-py${{ matrix.python }}
+          path: dist/*.whl
+          retention-days: 90
+          if-no-files-found: error
 
-    - name: Resolve release tag
-      id: release_tag
-      shell: bash
-      run: |
-        if [ "${{ github.event_name }}" = "release" ]; then
-          TAG="${{ github.event.release.tag_name }}"
-        else
-          TAG="${{ inputs.release_tag }}"
-        fi
-        if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
-          echo "Error: expected a SemVer-style tag starting with v, got: $TAG"
-          exit 1
-        fi
-        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+  # ────────────────────────────────────────────────────────────────────
+  # 4. Matrix completeness gate — block if any wheel silently dropped
+  # ────────────────────────────────────────────────────────────────────
+  verify-matrix-complete:
+    needs: [build-sdist, build-wheels]
+    name: Verify 20 wheels + 1 sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheel-*
+          path: dist
+          merge-multiple: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+      - name: Assert artifact counts
+        run: |
+          WHEEL_COUNT=$(find dist -name '*.whl' | wc -l | tr -d ' ')
+          SDIST_COUNT=$(find dist -name '*.tar.gz' | wc -l | tr -d ' ')
+          echo "────────────────────────────────────────"
+          ls -la dist/
+          echo "────────────────────────────────────────"
+          echo "Wheels: $WHEEL_COUNT  (expected 20)"
+          echo "Sdist:  $SDIST_COUNT  (expected 1)"
+          if [ "$WHEEL_COUNT" -ne 20 ]; then
+            echo "::error::Matrix incomplete — expected exactly 20 wheels, got $WHEEL_COUNT"
+            exit 1
+          fi
+          if [ "$SDIST_COUNT" -ne 1 ]; then
+            echo "::error::Expected 1 sdist, got $SDIST_COUNT"
+            exit 1
+          fi
+          echo "✅ 20 wheels + 1 sdist present"
 
-    - name: Verify version matches release tag
-      shell: bash
-      run: |
-        TAG="${{ steps.release_tag.outputs.tag }}"
-        TAG_VERSION=${TAG#v}
-        PACKAGE_VERSION=$(grep '^version = ' pyproject.toml | cut -d'"' -f2)
-        if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
-          echo "Error: Tag version ($TAG_VERSION) does not match package version ($PACKAGE_VERSION)"
-          exit 1
-        fi
-        echo "✅ Version check passed: $TAG_VERSION"
+  # ────────────────────────────────────────────────────────────────────
+  # 5. Upload to TestPyPI as smoke-test target
+  # ────────────────────────────────────────────────────────────────────
+  publish-testpypi:
+    needs: [resolve-tag, verify-matrix-complete]
+    name: Upload to TestPyPI
+    runs-on: ubuntu-latest
+    environment: Ondine
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheel-*
+          path: dist
+          merge-multiple: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+      - name: Upload to TestPyPI
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --repository-url https://test.pypi.org/legacy/ --skip-existing dist/*
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
 
-    - name: Build package (Rust + Python)
-      run: |
-        maturin build --release
-        echo "📦 Built package:"
-        ls -lh target/wheels/
+  # ────────────────────────────────────────────────────────────────────
+  # 6. Smoke test — install from TestPyPI on platforms that were broken
+  #    in v1.7.0-v1.9.1. These runners have NO Rust toolchain, so if a
+  #    wheel is missing, pip falls back to sdist and fails to build.
+  # ────────────────────────────────────────────────────────────────────
+  smoke-test:
+    needs: [resolve-tag, publish-testpypi]
+    name: Smoke ${{ matrix.os }} py${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: macos-14,         python: "3.10" }
+          - { os: macos-14,         python: "3.13" }
+          - { os: macos-13,         python: "3.11" }
+          - { os: windows-latest,   python: "3.10" }
+          - { os: windows-latest,   python: "3.13" }
+          - { os: ubuntu-24.04-arm, python: "3.12" }
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
 
-    - name: Verify package contents
-      run: |
-        echo "📋 Checking wheel contents..."
-        ls target/wheels/*.whl
-        echo "✅ Package verification complete"
+      - name: Install from TestPyPI (wheel-only, no source fallback)
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          # --only-binary ondine: refuses sdist fallback, errors hard if no wheel
+          # --extra-index-url prod PyPI: dependencies come from prod, package itself from test
+          # Retry: TestPyPI propagation can lag a few seconds after upload
+          for i in 1 2 3 4 5; do
+            if python -m pip install \
+                --index-url https://test.pypi.org/simple/ \
+                --extra-index-url https://pypi.org/simple/ \
+                --only-binary ondine \
+                "ondine==${{ needs.resolve-tag.outputs.version }}"; then
+              break
+            fi
+            echo "Attempt $i failed — waiting 15s for TestPyPI propagation"
+            sleep 15
+            if [ "$i" = "5" ]; then exit 1; fi
+          done
 
-    - name: Generate SBOM
-      run: |
-        pip install cyclonedx-bom
-        cyclonedx-py environment -o sbom.json
+      - name: Verify Rust extension loads (regression gate)
+        shell: bash
+        run: |
+          python -c "
+          from ondine._engine import EvidenceDB
+          db = EvidenceDB(':memory:')
+          print('✅ ${{ matrix.os }} py${{ matrix.python }}: wheel installed + Rust extension works')
+          "
 
-    - name: Sign artifacts with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.3.0
-      with:
-        inputs: target/wheels/*.whl
+  # ────────────────────────────────────────────────────────────────────
+  # 7. Production publish — Sigstore-sign, upload to PyPI
+  # ────────────────────────────────────────────────────────────────────
+  publish-prod:
+    needs: [resolve-tag, smoke-test]
+    name: Publish to PyPI (production)
+    runs-on: ubuntu-latest
+    environment: Ondine
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheel-*
+          path: dist
+          merge-multiple: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
 
-    - name: Publish to PyPI
-      env:
-        MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-      run: |
-        echo "Publishing to PyPI..."
-        maturin publish --skip-existing
+      - name: List artifacts
+        run: ls -la dist/
 
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: dist-packages
-        path: target/wheels/
-        retention-days: 30
+      - name: Sign wheels + sdist with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.3.0
+        with:
+          inputs: ./dist/*.whl ./dist/*.tar.gz
 
-    - name: Upload SBOM
-      uses: actions/upload-artifact@v4
-      with:
-        name: sbom
-        path: sbom.json
-        retention-days: 90
+      - name: Upload to PyPI
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --skip-existing dist/*.whl dist/*.tar.gz
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Archive signed release
+        uses: actions/upload-artifact@v4
+        with:
+          name: signed-release-${{ needs.resolve-tag.outputs.version }}
+          path: dist/
+          retention-days: 365

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ondine"
-version = "1.9.1"
+version = "1.10.0rc1"
 description = "Ondine - The LLM Dataset Engine. SDK for processing tabular datasets using LLMs with reliability, observability, and cost control"
 requires-python = ">=3.10"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ondine"
-version = "1.10.0rc1"
+version = "1.10.0"
 description = "Ondine - The LLM Dataset Engine. SDK for processing tabular datasets using LLMs with reliability, observability, and cost control"
 requires-python = ">=3.10"
 authors = [
@@ -136,6 +136,7 @@ features = ["pyo3/extension-module"]
 module-name = "ondine._engine"
 manifest-path = "crates/ondine-python/Cargo.toml"
 python-source = "."
+include = [{ path = "LICENSE", format = "sdist" }, { path = "README.md", format = "sdist" }]
 
 # Ruff configuration (replaces black, isort, flake8, etc.)
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -3480,7 +3480,7 @@ wheels = [
 
 [[package]]
 name = "ondine"
-version = "1.10.0rc1"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -3480,7 +3480,7 @@ wheels = [
 
 [[package]]
 name = "ondine"
-version = "1.9.1"
+version = "1.10.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Rewrites `publish-pypi.yml` as a 7-stage pipeline that guarantees every supported platform gets a binary wheel on PyPI.

- Matrix builds 20 wheels: 5 OS × 4 Python (3.10–3.13) via `PyO3/maturin-action`
- Hard gate asserts exactly 20 wheels + 1 sdist before publishing
- TestPyPI smoke-test installs wheels on 6 runners with **no Rust toolchain** (`--only-binary ondine`), catching the exact regression class from v1.7.0–v1.9.1
- Sigstore-signs artifacts before prod upload

## Root cause (v1.7.0–v1.9.1 regression)

PR #107 (commit `0f38a1b`, Mar 30 2026) switched build-backend hatchling→maturin and introduced `Cargo.toml`, but the publish workflow kept a single-job `maturin build` on `ubuntu-latest` + Python 3.11. CI tests on Mac/Win/arm64 installed from source with a Rust toolchain present, masking the fact that only `cp311-manylinux_x86_64` wheels reached PyPI. Users on Apple Silicon / Windows / Python 3.10/3.12/3.13 fell back to sdist and failed without `cc`/Rust.

## Pipeline

```
resolve-tag → build-sdist  ┐
                           ├─► verify-matrix-complete (20 wheels gate)
              build-wheels ┘                 ↓
                                       publish-testpypi
                                             ↓
                                       smoke-test (6 runners, fresh pip, no Rust)
                                             ↓
                                       publish-prod (Sigstore)
```

## Required before this can run

Add `TEST_PYPI_API_TOKEN` secret to the `Ondine` GitHub environment (scoped to the ondine project on https://test.pypi.org).

## Post-merge plan

1. Tag `v1.10.0-rc1`, verify TestPyPI install works on a fresh Mac
2. Promote to `v1.10.0` prod
3. Yank v1.7.0, v1.8.0, v1.8.1, v1.9.0, v1.9.1 from PyPI
4. Post-mortem issue + CHANGELOG entry

## Test plan

- [ ] Add `TEST_PYPI_API_TOKEN` secret
- [ ] Dispatch workflow against a test tag; confirm 20 wheels built
- [ ] Confirm smoke-test job installs cleanly on macos-14 / windows / ubuntu-arm
- [ ] Confirm Sigstore signing succeeds on prod publish
- [ ] Fresh `pip install ondine` on M1 Mac with no Rust toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened the release pipeline with staged validation gates, tag/version checks, separate sdist and multi-platform wheel builds, per-runner native-extension self-tests, an artifact-completeness gate, TestPyPI smoke testing that enforces wheel-only installs, and cryptographic signing plus archival before production upload.
* **Release**
  * Bumped package version to 1.10.0 and ensured LICENSE and README are included in source distributions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->