### PR TITLE
fix(ci): grant contents:write for Sigstore

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -33,8 +33,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
-  id-token: write  # Sigstore signing
+  contents: write  # Sigstore attaches signatures to the GitHub release
+  id-token: write  # Sigstore signing via OIDC
 
 jobs:
 


### PR DESCRIPTION
Sigstore needs contents:write to attach .sigstore bundles to the GitHub release. Blocked v1.10.0 publish.