### PR TITLE
fix: derive __version__ from metadata + 1.10.1

### DIFF
--- a/ondine/__init__.py
+++ b/ondine/__init__.py
@@ -20,7 +20,13 @@ warnings.filterwarnings("ignore", message=".*PyTorch.*TensorFlow.*Flax.*")
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
 
-__version__ = "1.9.1"
+try:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _pkg_version
+
+    __version__ = _pkg_version("ondine")
+except PackageNotFoundError:  # editable install without metadata
+    __version__ = "0.0.0+local"
 
 # Layer 4: High-Level API
 from ondine.api.dataset_processor import DatasetProcessor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ondine"
-version = "1.10.0"
+version = "1.10.1"
 description = "Ondine - The LLM Dataset Engine. SDK for processing tabular datasets using LLMs with reliability, observability, and cost control"
 requires-python = ">=3.10"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -3480,7 +3480,7 @@ wheels = [
 
 [[package]]
 name = "ondine"
-version = "1.10.0"
+version = "1.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Replaces hardcoded `__version__ = "1.9.1"` with `importlib.metadata.version('ondine')`. The hardcoded value drifted out of sync in v1.10.0 (wheel metadata was 1.10.0 but `import ondine; ondine.__version__` returned '1.9.1').

Single source of truth: `pyproject.toml` version field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version updated to 1.10.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->