### PR TITLE
R6: Colab quickstart notebook + Open in Colab badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Python 3.10+. Works with any LLM through [LiteLLM](https://github.com/BerriAI/li
 
 ## 30-second quickstart
 
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ptimizeroracle/ondine/blob/main/examples/ondine_quickstart.ipynb) · run the notebook below in a free Colab instance with a free Groq key — first output in under 30 seconds.
+
 ```python
 from ondine import PipelineBuilder
 

--- a/examples/ondine_quickstart.ipynb
+++ b/examples/ondine_quickstart.ipynb
@@ -1,0 +1,143 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ondine Quickstart\n",
+    "\n",
+    "**A prompt is a column.** This notebook runs a full Ondine pipeline in under 30 seconds using a free Groq API key \u2014 no credit card, no local install.\n",
+    "\n",
+    "Ondine turns LLM calls into a first-class DataFrame operation: define a column with natural language, and Ondine computes it at production scale. Cost tracking, retries, and concurrency are on by default."
+   ],
+   "id": "fcb0af51053a"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1 \u00b7 Install Ondine"
+   ],
+   "id": "c20803771dd0"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!pip install -q ondine"
+   ],
+   "id": "30528b5111bc"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2 \u00b7 Add your free Groq API key\n",
+    "\n",
+    "1. Get a free key at **[console.groq.com/keys](https://console.groq.com/keys)** (sign in, create key, copy).\n",
+    "2. In the Colab sidebar (\ud83d\udd11 icon), add a secret named `GROQ_API_KEY` and paste your key.\n",
+    "3. Run the cell below."
+   ],
+   "id": "b94327225f69"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from google.colab import userdata\n",
+    "\n",
+    "os.environ[\"GROQ_API_KEY\"] = userdata.get(\"GROQ_API_KEY\")\n",
+    "print(\"\u2713 Groq API key loaded\")"
+   ],
+   "id": "88288212732e"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3 \u00b7 Run the pipeline\n",
+    "\n",
+    "Three product descriptions in, a category column out \u2014 one builder chain, no boilerplate."
+   ],
+   "id": "612d099a596b"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from ondine import QuickPipeline\n",
+    "\n",
+    "data = pd.DataFrame({\n",
+    "    \"product\": [\n",
+    "        \"Apple iPhone 13 Pro Max 256GB\",\n",
+    "        \"Samsung Galaxy S22 Ultra 512GB\",\n",
+    "        'MacBook Pro 16\" M2 32GB RAM',\n",
+    "    ],\n",
+    "    \"description\": [\n",
+    "        \"Latest iPhone with advanced camera system\",\n",
+    "        \"Premium Android flagship with S Pen\",\n",
+    "        \"Powerful laptop for professionals\",\n",
+    "    ],\n",
+    "})\n",
+    "\n",
+    "pipeline = QuickPipeline.create(\n",
+    "    data=data,\n",
+    "    prompt=\"\"\"Categorize this product into exactly ONE of:\n",
+    "    - Electronics > Smartphones\n",
+    "    - Electronics > Laptops\n",
+    "    - Electronics > Accessories\n",
+    "\n",
+    "    Product: {product}\n",
+    "    Description: {description}\n",
+    "\n",
+    "    Category:\"\"\",\n",
+    "    output_columns=[\"category\"],\n",
+    "    model=\"llama-3.3-70b-versatile\",  # free-tier Groq model; provider auto-detected\n",
+    ")",
+    "\n",
+    "result = pipeline.execute()\n",
+    "print(result.data[[\"product\", \"category\"]])\n",
+    "print(f\"\\n{result.metrics.processed_rows} rows processed in {result.metrics.total_duration_seconds:.2f}s\")\n",
+    "print(f\"Total cost: ${result.costs.total_cost:.4f}\")"
+   ],
+   "id": "0c302cf9d169"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "- **Swap the model**: change `model=\"llama-3.3-70b-versatile\"` to any of 100+ LiteLLM providers (`openai/gpt-4o-mini`, `anthropic/claude-3.5-sonnet`, `ollama/qwen3.5` for local).\n",
+    "- **Add structure**: pass a Pydantic model to `.with_structured_output(...)` for typed columns.\n",
+    "- **Scale up**: point `data=` at a CSV and add `.with_max_budget(5.00)` for cost-capped batch runs.\n",
+    "\n",
+    "Full docs: **[docs.ondine.dev](https://docs.ondine.dev)** \u00b7 More examples: **[examples/](https://github.com/ptimizeroracle/ondine/tree/main/examples)**"
+   ],
+   "id": "9b74aecda83d"
+  }
+ ]
+}


### PR DESCRIPTION
## What

- Add `examples/ondine_quickstart.ipynb`: a minimal Colab notebook that runs a full Ondine pipeline in under 30 seconds using a free-tier Groq API key.
- Add an **Open in Colab** badge to the README quickstart section linking to the notebook.

## Why

Removes the install/setup barrier for first-time users. A new visitor can click the badge, add a free Groq key via Colab secrets, and see their first computed column in under 30 seconds — no local Python, no credit card.

## Notebook contents

1. `!pip install -q ondine`
2. Load a free Groq key from Colab's secrets sidebar (`GROQ_API_KEY`)
3. `QuickPipeline.create(...)` on a 3-row product DataFrame → category column, with metrics + cost printout

Uses `llama-3.3-70b-versatile`, a Groq free-tier model whose name auto-detects to the `groq` provider (consistent with `docs/guides/providers/groq.md`).

## Validation

- Notebook passes `nbformat.validate()` (nbformat 4.5, 8 cells, all with ids)
- API surface (`QuickPipeline.create`, `result.data`, `result.metrics.processed_rows`, `result.costs.total_cost`) verified against `ondine/api/quick.py` and `examples/01_quickstart.py`
- Provider auto-detection for `llama-3.3-70b-versatile` confirmed → `groq`

Closes the R6 Colab task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Open in Colab” link in the quickstart section for faster hands-on access.
  * Added a new interactive quickstart notebook that guides users through installation, setup, and running a sample workflow.
  * Included example output and next-step guidance for scaling up, changing models, and using structured results.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->