### PR TITLE
feat(api): add enrich() front-door facade

### DIFF
--- a/ondine/__init__.py
+++ b/ondine/__init__.py
@@ -34,6 +34,9 @@ from ondine.api.pipeline import Pipeline
 from ondine.api.pipeline_builder import PipelineBuilder
 from ondine.api.quick import QuickPipeline
 
+# Layer 5: Front doors — thin facades over Layer 4 (no own logic)
+from ondine.api.enrich import enrich
+
 # Context store (pluggable anti-hallucination backends)
 from ondine.context import (
     ContextStore,
@@ -62,6 +65,7 @@ from ondine.core.specifications import (
 
 __all__ = [
     "__version__",
+    "enrich",
     "Pipeline",
     "PipelineBuilder",
     "QuickPipeline",

--- a/ondine/api/enrich.py
+++ b/ondine/api/enrich.py
@@ -1,0 +1,93 @@
+"""Front-door facade: enrich() — the one-call path to LLM dataset enrichment.
+
+enrich() is a thin wrapper over QuickPipeline: it accepts the smallest common
+set of arguments, builds a pipeline, runs it once, and returns the enriched
+DataFrame. Anything beyond the named parameters is forwarded through an
+explicit allowlist so callers get a clean error rather than silent getattr
+magic. This is L5 — it owns no logic, only orchestration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pandas as pd
+
+from ondine.api.quick import QuickPipeline
+
+if TYPE_CHECKING:  # pragma: no cover - import only for type checkers
+    from decimal import Decimal
+
+# **options keys that map 1:1 to QuickPipeline.create parameters.
+# Anything not listed here is rejected so the surface stays auditable.
+_ALLOWED_OPTIONS: frozenset[str] = frozenset(
+    {
+        "temperature",
+        "max_tokens",
+        "batch_size",
+        "concurrency",
+        "provider",
+    }
+)
+
+
+def enrich(
+    data: str | Path | pd.DataFrame,
+    prompt: str,
+    output_columns: list[str] | str | None = None,
+    *,
+    model: str = "gpt-4o-mini",
+    schema: Any | None = None,
+    budget: float | Decimal | None = None,  # noqa: F821 — Decimal imported lazily
+    **options: Any,
+) -> pd.DataFrame:
+    """Enrich a dataset with a single LLM call per row.
+
+    Args:
+        data: CSV/Excel/Parquet/JSON file path or an in-memory DataFrame.
+        prompt: Prompt template with {placeholders} matching input columns.
+        output_columns: Output column name(s). Defaults to ``["output"]``.
+        model: Model identifier (default ``gpt-4o-mini``); provider auto-detected.
+        schema: Optional Pydantic model enabling native structured output.
+        budget: Optional maximum cost cap in USD.
+        **options: Recognized tuning knobs — ``temperature``, ``max_tokens``,
+            ``batch_size``, ``concurrency``, ``provider``. Unknown keys raise
+            TypeError.
+
+    Returns:
+        The enriched DataFrame (input columns plus output columns).
+
+    Raises:
+        TypeError: If an unrecognized keyword argument is passed.
+        ValueError: If the data, prompt, or budget is invalid (raised by
+            the underlying pipeline).
+    """
+    from decimal import Decimal
+
+    # Reject anything outside the allowlist (including reserved internal names
+    # like max_budget) before forwarding, so the contract is explicit.
+    unexpected = set(options) - _ALLOWED_OPTIONS
+    if unexpected:
+        raise TypeError(
+            f"enrich() got unexpected keyword argument(s): {sorted(unexpected)}. "
+            f"Allowed: {sorted(_ALLOWED_OPTIONS)}."
+        )
+
+    pipeline = QuickPipeline.create(
+        data=data,
+        prompt=prompt,
+        output_columns=output_columns,
+        model=model,
+        max_budget=budget,
+        **options,
+    )
+
+    # Schema is the one knob QuickPipeline.create doesn't expose; inject it via
+    # the same metadata channel that PipelineBuilder.with_structured_output uses
+    # (read by Pipeline.execute at the LLM-invocation stage).
+    if schema is not None:
+        pipeline.specifications.metadata["structured_output_model"] = schema
+
+    result = pipeline.execute()
+    return result.to_pandas()

--- a/tests/unit/test_enrich.py
+++ b/tests/unit/test_enrich.py
@@ -1,0 +1,230 @@
+"""Tests for ondine.enrich() front-door facade.
+
+The facade orchestrates two collaborators: QuickPipeline.create (builds the
+pipeline) and Pipeline.execute (runs it). These tests mock at that boundary
+and assert on the orchestration contract — what the facade forwards, what it
+injects, and what it returns — without dragging in the real pipeline machinery.
+"""
+
+from decimal import Decimal
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+from pydantic import BaseModel
+
+from ondine.api.enrich import enrich
+from ondine.core.models import CostEstimate, ExecutionResult, ProcessingStats
+
+
+class _StubPipeline:
+    """Minimal stand-in for a built Pipeline.
+
+    Records the specifications object the facade mutates (for schema injection
+    assertions) and returns a canned ExecutionResult from execute().
+    """
+
+    def __init__(self, result_df):
+        self.specifications = type(
+            "Specs", (), {"metadata": {}}
+        )()  # simple namespace w/ metadata dict
+        self._result_df = result_df
+        self.execute_calls = 0
+
+    def execute(self):
+        self.execute_calls += 1
+        return ExecutionResult(
+            data=self._result_df,
+            metrics=ProcessingStats(
+                total_rows=len(self._result_df),
+                processed_rows=len(self._result_df),
+                failed_rows=0,
+                skipped_rows=0,
+            ),
+            costs=CostEstimate(
+                total_cost=Decimal("0.01"),
+                total_tokens=10,
+                input_tokens=5,
+                output_tokens=5,
+                rows=len(self._result_df),
+                confidence="actual",
+            ),
+            success=True,
+        )
+
+
+def _patch_create(monkeypatch, result_df=None, capture=None):
+    """Replace QuickPipeline.create with a stub-returning fake.
+
+    Args:
+        result_df: DataFrame the stub's execute() will surface.
+        capture: dict that will be filled with the kwargs passed to create().
+    """
+    df = result_df if result_df is not None else pd.DataFrame({"output": ["ok"]})
+    stub_holder = {}
+
+    def fake_create(*args, **kwargs):
+        if capture is not None:
+            capture["args"] = args
+            capture["kwargs"] = kwargs
+        stub = _StubPipeline(df)
+        stub_holder["pipeline"] = stub
+        return stub
+
+    monkeypatch.setattr("ondine.api.enrich.QuickPipeline.create", fake_create)
+    return stub_holder
+
+
+class TestEnrich:
+    """Behavioral tests for the enrich() facade."""
+
+    def test_enrich_returns_result_dataframe(self, monkeypatch):
+        """enrich() executes the pipeline and returns its data as a DataFrame."""
+        out = pd.DataFrame({"text": ["a", "b"], "category": ["x", "y"]})
+        stub_holder = _patch_create(monkeypatch, result_df=out)
+
+        result = enrich(
+            pd.DataFrame({"text": ["a", "b"]}),
+            prompt="Categorize: {text}",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert "category" in result.columns
+        assert stub_holder["pipeline"].execute_calls == 1
+
+    def test_enrich_forwards_core_positional_args(self, monkeypatch):
+        """data, prompt, output_columns reach QuickPipeline.create unchanged."""
+        captured = {}
+        _patch_create(monkeypatch, capture=captured)
+
+        df = pd.DataFrame({"text": ["a"]})
+        enrich(df, prompt="Process: {text}", output_columns=["label"])
+
+        assert captured["kwargs"]["data"] is df
+        assert captured["kwargs"]["prompt"] == "Process: {text}"
+        assert captured["kwargs"]["output_columns"] == ["label"]
+
+    def test_enrich_forwards_model(self, monkeypatch):
+        """model keyword reaches QuickPipeline.create."""
+        captured = {}
+        _patch_create(monkeypatch, capture=captured)
+
+        enrich(pd.DataFrame({"text": ["a"]}), prompt="P: {text}", model="claude-3-sonnet")
+
+        assert captured["kwargs"]["model"] == "claude-3-sonnet"
+
+    def test_enrich_forwards_budget_to_create(self, monkeypatch):
+        """budget is forwarded as max_budget (QuickPipeline's param name)."""
+        captured = {}
+        _patch_create(monkeypatch, capture=captured)
+
+        enrich(
+            pd.DataFrame({"text": ["a"]}),
+            prompt="P: {text}",
+            budget=Decimal("5.0"),
+        )
+
+        assert captured["kwargs"]["max_budget"] == Decimal("5.0")
+
+    def test_enrich_budget_accepts_float_and_int(self, monkeypatch):
+        """budget accepts plain numeric types, not just Decimal."""
+        captured = {}
+        _patch_create(monkeypatch, capture=captured)
+        enrich(pd.DataFrame({"text": ["a"]}), prompt="P: {text}", budget=5.0)
+        assert captured["kwargs"]["max_budget"] == 5.0
+
+    def test_enrich_injects_schema_into_metadata(self, monkeypatch):
+        """schema is injected into the built pipeline's metadata for structured output."""
+
+        class MySchema(BaseModel):
+            label: str
+            score: float
+
+        stub_holder = _patch_create(monkeypatch)
+
+        enrich(
+            pd.DataFrame({"text": ["a"]}),
+            prompt="P: {text}",
+            output_columns=["label", "score"],
+            schema=MySchema,
+        )
+
+        metadata = stub_holder["pipeline"].specifications.metadata
+        assert metadata["structured_output_model"] is MySchema
+
+    def test_enrich_no_schema_leaves_metadata_clean(self, monkeypatch):
+        """Without schema, metadata is not polluted with structured-output keys."""
+        stub_holder = _patch_create(monkeypatch)
+
+        enrich(pd.DataFrame({"text": ["a"]}), prompt="P: {text}")
+
+        metadata = stub_holder["pipeline"].specifications.metadata
+        assert "structured_output_model" not in metadata
+
+    def test_enrich_forwards_allowed_options(self, monkeypatch):
+        """Recognized **options are forwarded to QuickPipeline.create."""
+        captured = {}
+        _patch_create(monkeypatch, capture=captured)
+
+        enrich(
+            pd.DataFrame({"text": ["a"]}),
+            prompt="P: {text}",
+            temperature=0.7,
+            max_tokens=100,
+            batch_size=25,
+            concurrency=10,
+            provider="groq",
+        )
+
+        kw = captured["kwargs"]
+        assert kw["temperature"] == 0.7
+        assert kw["max_tokens"] == 100
+        assert kw["batch_size"] == 25
+        assert kw["concurrency"] == 10
+        assert kw["provider"] == "groq"
+
+    def test_enrich_rejects_unknown_option(self, monkeypatch):
+        """Unknown **options raise TypeError (explicit allowlist, no getattr magic)."""
+        _patch_create(monkeypatch)
+
+        with pytest.raises(TypeError, match="unexpected"):
+            enrich(
+                pd.DataFrame({"text": ["a"]}),
+                prompt="P: {text}",
+                bogus_param=123,
+            )
+
+    def test_enrich_rejects_reserved_option_names(self, monkeypatch):
+        """First-class params (model/schema/budget) can't be re-passed via **options."""
+        _patch_create(monkeypatch)
+
+        with pytest.raises(TypeError, match="unexpected"):
+            enrich(
+                pd.DataFrame({"text": ["a"]}),
+                prompt="P: {text}",
+                max_budget=5.0,  # internal name — must be rejected
+            )
+
+    def test_enrich_executes_exactly_once(self, monkeypatch):
+        """enrich() runs the pipeline once per call (no double execution)."""
+        stub_holder = _patch_create(monkeypatch)
+
+        enrich(pd.DataFrame({"text": ["a"]}), prompt="P: {text}")
+
+        assert stub_holder["pipeline"].execute_calls == 1
+
+
+class TestEnrichAcceptsFilePaths:
+    """enrich() passes data through to QuickPipeline, which handles file paths."""
+
+    def test_enrich_forwards_file_path(self, monkeypatch, tmp_path):
+        """A path-like data argument is forwarded as-is (QuickPipeline loads it)."""
+        captured = {}
+        _patch_create(monkeypatch, capture=captured)
+
+        csv = tmp_path / "data.csv"
+        pd.DataFrame({"text": ["a"]}).to_csv(csv, index=False)
+
+        enrich(csv, prompt="P: {text}")
+
+        assert captured["kwargs"]["data"] == csv


### PR DESCRIPTION
Adds ondine.enrich() — a one-function API facade over QuickPipeline.

import ondine
df = ondine.enrich(df, "Classify: {review}", ["sentiment"])

Returns enriched DataFrame directly. Input type preserved.
Tests: 12/12 pass. Merge order: 1st (no deps).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a top-level `enrich` function for one-call LLM dataset enrichment.
  * Supports data frames, file paths, prompts, output columns, models, budgets, schemas, and processing options.
  * Returns enriched results as a pandas DataFrame.
  * Added validation for unsupported options and support for structured output schemas.

* **Tests**
  * Added coverage for parameter forwarding, schema handling, file paths, result conversion, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->