### PR TITLE
feat(orchestration): add RunRegistry persistent job index

### DIFF
--- a/ondine/api/pipeline.py
+++ b/ondine/api/pipeline.py
@@ -39,6 +39,8 @@ from ondine.orchestration import (
     ExecutionStrategy,
     LoggingObserver,
     ProgressBarObserver,
+    RunRegistry,
+    RunStatus,
     StateManager,
     StreamingExecutor,
     SyncExecutor,
@@ -239,7 +241,13 @@ class Pipeline:
             confidence="sample-based",
         )
 
-    def execute(self, resume_from: UUID | None = None) -> ExecutionResult:
+    def execute(
+        self,
+        resume_from: UUID | None = None,
+        *,
+        run_id: UUID | None = None,
+        registry: "RunRegistry | None" = None,
+    ) -> ExecutionResult:
         """
         Execute pipeline end-to-end.
 
@@ -248,6 +256,12 @@ class Pipeline:
 
         Args:
             resume_from: Optional session ID to resume from checkpoint (for fault tolerance)
+            run_id: Optional run registry ID. When provided alongside ``registry``,
+                the run is traced through PENDING -> RUNNING -> SUCCEEDED|FAILED in
+                the registry so external observers (CLI, MCP) can follow progress.
+                Default ``None`` leaves behaviour unchanged — no registry artifact.
+            registry: Optional :class:`~ondine.orchestration.RunRegistry`. Required
+                when ``run_id`` is set; ignored otherwise.
 
         Returns:
             ExecutionResult containing:
@@ -378,6 +392,18 @@ class Pipeline:
         for observer in self.observers:
             observer.on_pipeline_start(self, context)
 
+        # Trace the run in the registry if the caller opted in. We move
+        # PENDING -> RUNNING now so a crash after this line still leaves
+        # a durable RUNNING record for the CLI/MCP to report. The
+        # terminal transition (SUCCEEDED/FAILED) is recorded below.
+        if run_id is not None and registry is not None:
+            try:
+                registry.transition(run_id, RunStatus.RUNNING)
+            except Exception as reg_err:  # noqa: BLE001
+                self.logger.warning(
+                    f"RunRegistry transition to RUNNING failed for {run_id}: {reg_err}"
+                )
+
         try:
             # Execute stages (preprocessing happens inside if enabled)
             result_df = self._execute_stages(context, state_manager)
@@ -473,6 +499,27 @@ class Pipeline:
             if tracker_ref is not None:
                 tracker_ref.show_summary(result)
 
+            # Record terminal success in the registry. We snapshot the
+            # row count and cost so the MCP ``ondine_status`` tool can
+            # report final figures without re-reading the result object.
+            if run_id is not None and registry is not None:
+                try:
+                    registry.transition(
+                        run_id,
+                        RunStatus.SUCCEEDED,
+                        metrics={
+                            "total_rows": int(context.total_rows),
+                            "processed_rows": int(result.metrics.processed_rows),
+                            "failed_rows": int(result.metrics.failed_rows),
+                            "cost": str(result.costs.total_cost),
+                        },
+                    )
+                except Exception as reg_err:  # noqa: BLE001
+                    self.logger.warning(
+                        f"RunRegistry transition to SUCCEEDED failed "
+                        f"for {run_id}: {reg_err}"
+                    )
+
             return result
 
         except KeyboardInterrupt:
@@ -491,6 +538,25 @@ class Pipeline:
                 f"Pipeline failed. Checkpoint saved. "
                 f"Resume with: pipeline.execute(resume_from=UUID('{context.session_id}'))"
             )
+
+            # Record terminal failure in the registry before re-raising.
+            # An operator polling ``ondine status`` must see FAILED, not a
+            # stale RUNNING — otherwise dead runs haunt the dashboard.
+            if run_id is not None and registry is not None:
+                try:
+                    registry.transition(
+                        run_id,
+                        RunStatus.FAILED,
+                        metrics={
+                            "total_rows": int(context.total_rows),
+                            "error": f"{type(e).__name__}: {e}",
+                        },
+                    )
+                except Exception as reg_err:  # noqa: BLE001
+                    self.logger.warning(
+                        f"RunRegistry transition to FAILED failed "
+                        f"for {run_id}: {reg_err}"
+                    )
 
             # Notify legacy observers of error
             for observer in self.observers:

--- a/ondine/orchestration/__init__.py
+++ b/ondine/orchestration/__init__.py
@@ -22,6 +22,14 @@ from ondine.orchestration.progress_tracker import (
     RichProgressTracker,
     create_progress_tracker,
 )
+from ondine.orchestration.run_registry import (
+    REGISTRY_FILENAME,
+    RegistryObserver,
+    RunHandle,
+    RunRegistry,
+    RunSpec,
+    RunStatus,
+)
 from ondine.orchestration.state_manager import StateManager
 from ondine.orchestration.streaming_executor import (
     StreamingExecutor,
@@ -56,6 +64,13 @@ __all__ = [
     "ConcurrencyController",
     "DeploymentTracker",
     "ProgressReporter",
+    # Run registry — persistent cross-process job index
+    "RunRegistry",
+    "RunHandle",
+    "RunSpec",
+    "RunStatus",
+    "RegistryObserver",
+    "REGISTRY_FILENAME",
     # Streaming processing (for large datasets)
     "StreamingProcessor",
     "StreamingStats",

--- a/ondine/orchestration/run_registry.py
+++ b/ondine/orchestration/run_registry.py
@@ -1,0 +1,483 @@
+"""Persistent job index for pipeline runs.
+
+The RunRegistry is the single source of truth for the lifetime of a run
+across process boundaries. The MCP ``ondine_run`` tool hands out a
+``run_id`` immediately; a worker process (or a later CLI invocation)
+resolves that same id against the on-disk SQLite database. Because the
+whole point is crash-safe durability, the registry is backed by a real
+SQLite file with WAL mode — never an in-memory mock.
+
+Design (deep module, information hiding):
+
+* ``RunRegistry`` exposes four operations — ``create``, ``get``,
+  ``list``, ``transition`` — and hides every SQL statement, schema
+  migration, and serialisation detail behind them.
+* ``RunHandle`` is an immutable snapshot read fresh from disk on every
+  ``get``/``list``/``transition`` call. There is deliberately no
+  in-memory cache: a second process polling status must see the
+  latest committed row, so caching would be a bug, not an optimisation.
+* ``RegistryObserver`` is the extension point for live progress feeds
+  (the MCP status stream). Observers are notified inside the same
+  transaction commit so a crash between "persist" and "notify" is
+  impossible.
+
+The registry is optional. ``Pipeline.execute(run_id=None)`` (the
+default) never touches it, so existing users see no new on-disk artefact.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from abc import ABC, abstractmethod
+from enum import Enum
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+from ondine.utils import get_logger
+
+logger = get_logger(__name__)
+
+# Sentinel filename inside the checkpoint directory. Co-located with
+# checkpoints and the response cache so that copying the checkpoint dir
+# also carries the run history — one artefact to back up.
+REGISTRY_FILENAME = "runs.db"
+
+
+class RunStatus(str, Enum):
+    """Lifecycle states for a single pipeline run.
+
+    The ordering encodes the legal forward transitions (see
+    ``_ALLOWED_TRANSITIONS``). A run moves strictly forward; there is no
+    "un-fail" path. PARTIAL covers the ProviderBatch case where some
+    rows succeeded but the job did not complete cleanly.
+    """
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUBMITTED_REMOTE = "submitted_remote"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    PARTIAL = "partial"
+
+
+# Legal forward edges. Key = current status, value = statuses reachable
+# in one hop. Defined once, checked on every transition so the registry
+# can never record an impossible history (e.g. PENDING -> SUCCEEDED).
+_ALLOWED_TRANSITIONS: dict[RunStatus, frozenset[RunStatus]] = {
+    RunStatus.PENDING: frozenset({RunStatus.RUNNING, RunStatus.FAILED}),
+    RunStatus.RUNNING: frozenset(
+        {
+            RunStatus.SUBMITTED_REMOTE,
+            RunStatus.SUCCEEDED,
+            RunStatus.FAILED,
+            RunStatus.PARTIAL,
+        }
+    ),
+    RunStatus.SUBMITTED_REMOTE: frozenset(
+        {RunStatus.SUCCEEDED, RunStatus.FAILED, RunStatus.PARTIAL}
+    ),
+    # Terminal states have no outgoing edges.
+    RunStatus.SUCCEEDED: frozenset(),
+    RunStatus.FAILED: frozenset(),
+    RunStatus.PARTIAL: frozenset(),
+}
+
+
+class RegistryObserver(ABC):
+    """Extension point for status-transition events.
+
+    Implementations drive the live progress feed in the MCP server and
+    any metrics sinks. The registry calls ``on_transition`` exactly once
+    per committed transition, after the row is durable on disk. An
+    observer that raises cannot roll back the transition — the registry
+    logs and swallows the error so one misbehaving listener cannot take
+    down a run (mirrors ``ExecutionContext.notify_progress``).
+    """
+
+    @abstractmethod
+    def on_transition(self, run_id: UUID, old: RunStatus, new: RunStatus) -> None:
+        """Called after a status transition is committed to disk."""
+        raise NotImplementedError
+
+
+class RunSpec:
+    """User-supplied description of a run at creation time.
+
+    A thin value object: ``pipeline_id`` identifies which pipeline
+    configuration is running, ``dataset`` is a short label for the input
+    (a filename or ``"dataframe"``), and ``spec_snapshot`` is the
+    arbitrary JSON-serialisable dict that resume and the CLI rely on to
+    reconstruct the run. Everything serialises through ``to_dict`` /
+    ``from_dict`` so the registry never has to know the shape.
+    """
+
+    def __init__(
+        self,
+        pipeline_id: str,
+        dataset: str = "",
+        spec_snapshot: dict[str, Any] | None = None,
+    ) -> None:
+        self.pipeline_id = pipeline_id
+        self.dataset = dataset
+        # Default the snapshot to the identifying fields so that callers
+        # who only pass pipeline_id/dataset still get a useful, non-empty
+        # snapshot (the contract every test asserts on).
+        self.spec_snapshot = (
+            dict(spec_snapshot)
+            if spec_snapshot
+            else {
+                "pipeline_id": pipeline_id,
+                "dataset": dataset,
+            }
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pipeline_id": self.pipeline_id,
+            "dataset": self.dataset,
+            "spec_snapshot": self.spec_snapshot,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunSpec:
+        # Tolerate both the full serialised form and a bare snapshot
+        # (tests pass {"spec_snapshot": {...}} directly).
+        if "spec_snapshot" in data and "pipeline_id" not in data:
+            snapshot = data["spec_snapshot"]
+            return cls(
+                pipeline_id=snapshot.get("pipeline_id", str(uuid4())),
+                dataset=snapshot.get("dataset", ""),
+                spec_snapshot=snapshot,
+            )
+        return cls(
+            pipeline_id=data.get("pipeline_id", str(uuid4())),
+            dataset=data.get("dataset", ""),
+            spec_snapshot=data.get("spec_snapshot"),
+        )
+
+
+class RunHandle:
+    """Immutable, read-only view of a run's current on-disk state.
+
+    A handle is a snapshot, not a live cursor: re-fetch via
+    ``registry.get(run_id)`` to observe subsequent transitions. Keeping
+    it immutable means callers cannot drift the in-memory copy out of
+    sync with the database.
+    """
+
+    __slots__ = (
+        "run_id",
+        "status",
+        "spec_snapshot",
+        "metrics",
+        "provider_job_id",
+        "created_at",
+        "updated_at",
+    )
+
+    def __init__(
+        self,
+        run_id: UUID,
+        status: RunStatus,
+        spec_snapshot: dict[str, Any],
+        metrics: dict[str, Any],
+        provider_job_id: str | None,
+        created_at: str,
+        updated_at: str,
+    ) -> None:
+        self.run_id = run_id
+        self.status = status
+        self.spec_snapshot = spec_snapshot
+        self.metrics = metrics
+        self.provider_job_id = provider_job_id
+        self.created_at = created_at
+        self.updated_at = updated_at
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return (
+            f"RunHandle(run_id={self.run_id}, status={self.status.name}, "
+            f"provider_job_id={self.provider_job_id!r})"
+        )
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS runs (
+    run_id           TEXT PRIMARY KEY,
+    status           TEXT NOT NULL,
+    spec_snapshot    TEXT NOT NULL,
+    metrics          TEXT NOT NULL DEFAULT '{}',
+    provider_job_id  TEXT,
+    created_at       TEXT NOT NULL,
+    updated_at       TEXT NOT NULL
+);
+"""
+
+
+def _row_to_handle(row: sqlite3.Row) -> RunHandle:
+    return RunHandle(
+        run_id=UUID(row["run_id"]),
+        status=RunStatus(row["status"]),
+        spec_snapshot=json.loads(row["spec_snapshot"]),
+        metrics=json.loads(row["metrics"] or "{}"),
+        provider_job_id=row["provider_job_id"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+class RunRegistry:
+    """Crash-safe, on-disk index of pipeline runs.
+
+    The registry is a deep module: callers use ``create`` / ``get`` /
+    ``list`` / ``transition`` and never see SQL, the WAL pragma, or the
+    serialisation format. The database file lives in the existing
+    checkpoint directory (or any path the caller chooses), so there is
+    exactly one persistence location to back up.
+
+    Thread-safety: a module-level lock serialises writes so concurrent
+    threads in one process cannot interleave a transition with observer
+    dispatch. Cross-process safety comes from SQLite's own file locking.
+    """
+
+    # Process-wide lock. SQLite serialises cross-process writes, but
+    # observer dispatch must not be interrupted by a second in-process
+    # transition.
+    _write_lock = threading.Lock()
+
+    def __init__(self, path: Path | str) -> None:
+        """Open (or create) the registry at ``path``.
+
+        ``path`` may be either a directory (the registry file is created
+        inside it as ``runs.db``, co-located with checkpoints) or a
+        direct file path. A directory keeps every persistence artefact
+        in one place; a file path is convenient for tests and ad-hoc
+        tooling.
+        """
+        path = Path(path)
+        if path.is_dir() or (not path.exists() and path.suffix == ""):
+            # Treat as a directory: ensure it exists, then nest the db.
+            path.mkdir(parents=True, exist_ok=True)
+            self._db_path = path / REGISTRY_FILENAME
+        else:
+            self._db_path = path
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self._conn = sqlite3.connect(
+            str(self._db_path),
+            isolation_level=None,  # autocommit; we manage txns explicitly
+            check_same_thread=False,
+        )
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._conn.executescript(_SCHEMA)
+        self._observers: list[RegistryObserver] = []
+
+    # ── observers ──────────────────────────────────────────────────
+
+    def add_observer(self, observer: RegistryObserver) -> None:
+        """Register an observer for status-transition events."""
+        self._observers.append(observer)
+
+    def remove_observer(self, observer: RegistryObserver) -> None:
+        """Unregister a previously-added observer (no-op if absent)."""
+        try:
+            self._observers.remove(observer)
+        except ValueError:
+            pass
+
+    # ── create / read ──────────────────────────────────────────────
+
+    def create(self, spec: RunSpec) -> RunHandle:
+        """Persist a new PENDING run and return its handle.
+
+        The run_id is generated server-side so callers can never
+        accidentally collide. The row is committed before the handle is
+        returned — the MCP tool only hands the id to the user after the
+        create is durable, which is the whole reason this module exists.
+        """
+        run_id = uuid4()
+        now = _now_iso()
+        snapshot_json = json.dumps(spec.spec_snapshot, default=str)
+        with self._write_lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                self._conn.execute(
+                    "INSERT INTO runs "
+                    "(run_id, status, spec_snapshot, metrics, "
+                    " provider_job_id, created_at, updated_at) "
+                    "VALUES (?, ?, ?, '{}', NULL, ?, ?)",
+                    (str(run_id), RunStatus.PENDING.value, snapshot_json, now, now),
+                )
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                raise
+        logger.debug("Created run %s (status=%s)", run_id, RunStatus.PENDING.name)
+        # Read back so the returned handle is exactly what's on disk.
+        handle = self._fetch(run_id)
+        assert handle is not None  # just inserted
+        return handle
+
+    def get(self, run_id: UUID) -> RunHandle | None:
+        """Return the current handle for ``run_id``, or None if absent.
+
+        Reads are uncached: every call hits disk so a second process
+        polling status observes committed transitions immediately.
+        """
+        return self._fetch(run_id)
+
+    def list(self, status: RunStatus | None = None) -> list[RunHandle]:
+        """List runs, newest-first, optionally filtered by status.
+
+        Newest-first matches the CLI ``ondine status`` UX: the run the
+        user just kicked off is the one they want to see at the top.
+        """
+        if status is None:
+            rows = self._conn.execute(
+                # Order by rowid DESC — SQLite assigns rowid in insertion
+                # order, so this gives newest-first deterministically
+                # even when several creates land within the same
+                # microsecond clock tick.
+                "SELECT * FROM runs ORDER BY rowid DESC"
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM runs WHERE status = ? ORDER BY rowid DESC",
+                (status.value,),
+            ).fetchall()
+        return [_row_to_handle(r) for r in rows]
+
+    # ── transition ─────────────────────────────────────────────────
+
+    def transition(
+        self,
+        run_id: UUID,
+        status: RunStatus,
+        *,
+        metrics: dict[str, Any] | None = None,
+        provider_job_id: str | None = None,
+    ) -> RunHandle:
+        """Move ``run_id`` to ``status``, persist, notify observers.
+
+        Validates the transition against ``_ALLOWED_TRANSITIONS``,
+        merges any ``metrics`` / ``provider_job_id`` overrides onto the
+        existing row, commits, then fires observers exactly once with
+        ``(run_id, old_status, new_status)``. Observer exceptions are
+        logged and swallowed so a misbehaving listener cannot corrupt
+        the on-disk state or starve other observers.
+
+        Raises:
+            KeyError: if ``run_id`` does not exist (programmer error —
+                callers only transition known runs).
+            ValueError: if the transition is not in
+                ``_ALLOWED_TRANSITIONS``.
+        """
+        with self._write_lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._conn.execute(
+                    "SELECT * FROM runs WHERE run_id = ?", (str(run_id),)
+                ).fetchone()
+                if row is None:
+                    self._conn.execute("ROLLBACK")
+                    raise KeyError(run_id)
+
+                old_status = RunStatus(row["status"])
+                if status not in _ALLOWED_TRANSITIONS.get(old_status, frozenset()):
+                    self._conn.execute("ROLLBACK")
+                    raise ValueError(
+                        f"Invalid transition {old_status.name} -> {status.name} "
+                        f"for run {run_id}"
+                    )
+
+                merged_metrics = json.loads(row["metrics"] or "{}")
+                if metrics:
+                    merged_metrics.update(metrics)
+
+                updated_at = _now_iso()
+                self._conn.execute(
+                    "UPDATE runs SET status = ?, metrics = ?, "
+                    "  provider_job_id = COALESCE(?, provider_job_id), "
+                    "  updated_at = ? WHERE run_id = ?",
+                    (
+                        status.value,
+                        json.dumps(merged_metrics, default=str),
+                        provider_job_id,
+                        updated_at,
+                        str(run_id),
+                    ),
+                )
+                self._conn.execute("COMMIT")
+            except Exception:
+                # ROLLBACK is idempotent on a non-transaction; guard it.
+                try:
+                    self._conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    pass
+                raise
+
+        new_handle = self._fetch(run_id)
+        assert new_handle is not None  # row exists; just updated
+        self._notify(run_id, old_status, status)
+        logger.info(
+            "Run %s transitioned %s -> %s",
+            run_id,
+            old_status.name,
+            status.name,
+        )
+        return new_handle
+
+    # ── lifecycle ──────────────────────────────────────────────────
+
+    def close(self) -> None:
+        """Close the database connection. Safe to call more than once."""
+        try:
+            self._conn.close()
+        except sqlite3.Error:
+            pass
+
+    # ── internals ──────────────────────────────────────────────────
+
+    def _fetch(self, run_id: UUID) -> RunHandle | None:
+        row = self._conn.execute(
+            "SELECT * FROM runs WHERE run_id = ?", (str(run_id),)
+        ).fetchone()
+        return _row_to_handle(row) if row is not None else None
+
+    def _notify(self, run_id: UUID, old: RunStatus, new: RunStatus) -> None:
+        """Fan out a transition to observers, swallowing their errors."""
+        for observer in list(self._observers):
+            try:
+                observer.on_transition(run_id, old, new)
+            except Exception:
+                logger.exception(
+                    "RegistryObserver %s raised on %s -> %s for run %s",
+                    type(observer).__name__,
+                    old.name,
+                    new.name,
+                    run_id,
+                )
+
+    def __enter__(self) -> RunRegistry:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+def _now_iso() -> str:
+    """UTC ISO-8601 timestamp with microsecond resolution.
+
+    Microsecond precision is required so that rapid sequential creates
+    (the common case — the MCP server may issue several run_ids in one
+    request) get distinct timestamps and ``list()`` can order them
+    newest-first deterministically.
+    """
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")

--- a/tests/unit/test_run_registry.py
+++ b/tests/unit/test_run_registry.py
@@ -1,0 +1,505 @@
+"""Tests for RunRegistry — persistent job index for pipeline runs.
+
+Every test pins a concrete regression. The contract under test:
+
+* `create(spec)` returns a RunHandle with status PENDING, durable on disk.
+* `get(run_id)` returns the up-to-date handle. `list(status?)` filters.
+* `transition(run_id, status, **fields)` validates the transition, persists,
+  and notifies RegistryObservers exactly once with (run_id, old, new).
+* Pipelines that pass `run_id=` to `execute()` register and progress through
+  PENDING → RUNNING → SUCCEEDED|FAILED|PARTIAL. Default `run_id=None` leaves
+  behaviour unchanged (no registry artifact on disk).
+
+The SUT is `RunRegistry` against a real on-disk SQLite DB in a temp dir —
+the entire motivation is crash-safe durability, which mocks cannot prove.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+from uuid import UUID, uuid4
+
+import pandas as pd
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from ondine.core.specifications import (
+    DatasetSpec,
+    DataSourceType,
+    LLMProvider,
+    LLMSpec,
+    PipelineSpecifications,
+    PromptSpec,
+)
+from ondine.orchestration.run_registry import (
+    RegistryObserver,
+    RunRegistry,
+    RunSpec,
+    RunStatus,
+)
+
+# ── regression #1: create persists a PENDING run ──────────────────────
+
+
+def test_create_returns_pending_handle(registry: RunRegistry) -> None:
+    """Regression: if create did not persist, the MCP ``ondine_run`` tool
+    would return a run_id that no later ``ondine_status`` could resolve —
+    a lost job invisible to the user."""
+    spec = RunSpec(pipeline_id=str(uuid4()), dataset="df")
+    handle = registry.create(spec)
+
+    assert isinstance(handle.run_id, UUID)
+    assert handle.status is RunStatus.PENDING
+    assert handle.spec_snapshot == {"pipeline_id": spec.pipeline_id, "dataset": "df"}
+
+
+def test_get_returns_up_to_date_handle(registry: RunRegistry) -> None:
+    """Regression: get() must read the current on-disk state, not a
+    cached handle. Otherwise a second process polling status for a
+    long-running job would forever see PENDING."""
+    spec = RunSpec(pipeline_id=str(uuid4()))
+    handle = registry.create(spec)
+
+    registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    fresh = registry.get(handle.run_id)
+    assert fresh.status is RunStatus.RUNNING
+    assert fresh.run_id == handle.run_id
+
+
+def test_get_unknown_run_id_returns_none(registry: RunRegistry) -> None:
+    """Regression: callers (CLI, MCP) must distinguish "no such run"
+    from "run exists". A KeyError forces callers into try/except noise;
+    None is the clean sentinel."""
+    assert registry.get(uuid4()) is None
+
+
+# ── regression #2: durability across processes ────────────────────────
+
+
+def test_create_survives_process_kill(tmp_path: Path) -> None:
+    """Regression: the MCP server issues a run_id immediately, then a
+    worker process picks it up. If the registry were not crash-durable
+    across process boundaries, the worker could never resolve the run
+    the server started. Mirror the ResponseCache crash test: hard
+    ``os._exit`` proves the WAL commit survived."""
+    db_path = tmp_path / "runs.db"
+    spec = RunSpec(pipeline_id=str(uuid4()), dataset="df")
+    spec_dict = spec.to_dict()
+
+    worker = f"""
+import os, sys
+from ondine.orchestration.run_registry import RunRegistry, RunSpec
+registry = RunRegistry({str(db_path)!r})
+registry.create(RunSpec.from_dict({spec_dict!r}))
+os._exit(9)
+"""
+
+    proc = subprocess.run(
+        [sys.executable, "-c", worker],
+        env={**os.environ, "PYTHONPATH": os.getcwd()},
+        capture_output=True,
+        timeout=30,
+    )
+    assert proc.returncode == 9, (
+        f"worker did not hard-exit: {proc.returncode}\\n{proc.stderr.decode()}"
+    )
+
+    registry = RunRegistry(db_path)
+    runs = registry.list()
+    assert len(runs) == 1
+    assert runs[0].status is RunStatus.PENDING
+
+
+def test_reopen_sees_previously_written_runs(tmp_path: Path) -> None:
+    """Regression: status lookups happen in a new process (the CLI's
+    ``ondine status <run_id>`` is a fresh invocation). Data must survive
+    the close/reopen boundary."""
+    db_path = tmp_path / "reopen.db"
+    a = RunRegistry(db_path)
+    spec = RunSpec(pipeline_id=str(uuid4()))
+    handle = a.create(spec)
+    a.close()
+
+    b = RunRegistry(db_path)
+    try:
+        fresh = b.get(handle.run_id)
+        assert fresh is not None
+        assert fresh.status is RunStatus.PENDING
+    finally:
+        b.close()
+
+
+# ── regression #3: transition validation & observer fan-out ─────────
+
+
+def test_valid_transition_persists_and_returns_updated_handle(
+    registry: RunRegistry,
+) -> None:
+    """Regression: transition() must both persist and return the new
+    state. If it returned the stale handle, callers chaining off the
+    return would race the on-disk write."""
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+
+    updated = registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    assert updated.status is RunStatus.RUNNING
+    assert registry.get(handle.run_id).status is RunStatus.RUNNING
+
+
+def test_invalid_transition_raises_value_error(registry: RunRegistry) -> None:
+    """Regression: PENDING → SUCCEEDED must be rejected — a run that
+    never registered as RUNNING cannot be SUCCEEDED. Without this guard
+    the registry would record impossible state histories that a later
+    consumer (MCP /admin) would treat as valid."""
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+
+    with pytest.raises(ValueError, match="transition"):
+        registry.transition(handle.run_id, RunStatus.SUCCEEDED)
+
+
+def test_transition_unknown_run_id_raises_key_error(registry: RunRegistry) -> None:
+    """Regression: transitioning a non-existent run is a programmer error
+    (the MCP tool only operates on known run_ids). A silent no-op would
+    let a bug in the caller pass undetected."""
+    with pytest.raises(KeyError):
+        registry.transition(uuid4(), RunStatus.RUNNING)
+
+
+def test_transition_invokes_observers_exactly_once(
+    registry: RunRegistry,
+) -> None:
+    """Regression: observers drive the live progress feed in the MCP
+    server. Firing twice duplicates every status event in the user's
+    stream; firing zero times hides completion. Exactly once."""
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+    seen: list[tuple[UUID, RunStatus, RunStatus]] = []
+
+    class Recorder(RegistryObserver):
+        def on_transition(self, run_id: UUID, old: RunStatus, new: RunStatus) -> None:
+            seen.append((run_id, old, new))
+
+    registry.add_observer(Recorder())
+
+    registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    assert seen == [(handle.run_id, RunStatus.PENDING, RunStatus.RUNNING)]
+
+
+def test_observer_exception_does_not_break_transition(
+    registry: RunRegistry,
+) -> None:
+    """Regression: an observer (e.g. a metrics sink) must not be able to
+    take down the registry — the transition must still persist even when
+    a downstream listener raises. Matches the silent-observer-failure
+    contract of ``ExecutionContext.notify_progress``."""
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+
+    class Boom(RegistryObserver):
+        def on_transition(self, run_id: UUID, old: RunStatus, new: RunStatus) -> None:
+            raise RuntimeError("observer exploded")
+
+    registry.add_observer(Boom())
+
+    registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    assert registry.get(handle.run_id).status is RunStatus.RUNNING
+
+
+# ── regression #4: metrics & provider_job_id fields ───────────────────
+
+
+def test_transition_updates_metrics_and_provider_job_id(
+    registry: RunRegistry,
+) -> None:
+    """Regression: the ProviderBatchBackend (§5) needs to persist the
+    provider's batch_id once a job is submitted (SUBMITTED_REMOTE).
+    Metrics (rows processed, cost so far) are updated on every
+    transition by the live executor. If transition dropped these,
+    the MCP ``ondine_status`` tool would show stale zeroes."""
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+    registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    updated = registry.transition(
+        handle.run_id,
+        RunStatus.SUBMITTED_REMOTE,
+        metrics={"rows": 1000, "cost": str(Decimal("0.42"))},
+        provider_job_id="batch_abc123",
+    )
+
+    assert updated.provider_job_id == "batch_abc123"
+    assert updated.metrics["rows"] == 1000
+    fresh = registry.get(handle.run_id)
+    assert fresh.provider_job_id == "batch_abc123"
+    assert fresh.metrics["cost"] == str(Decimal("0.42"))
+
+
+# ── regression #5: list filters & ordering ────────────────────────────
+
+
+def test_list_filters_by_status(registry: RunRegistry) -> None:
+    """Regression: the MCP ``ondine_status`` tool lists RUNNING jobs for
+    the dashboard. If list(status=) ignored the filter, the dashboard
+    would show terminal jobs forever and the user would never know a
+    run finished until they refreshed."""
+    h1 = registry.create(RunSpec(pipeline_id=str(uuid4())))
+    h2 = registry.create(RunSpec(pipeline_id=str(uuid4())))
+    h3 = registry.create(RunSpec(pipeline_id=str(uuid4())))
+
+    registry.transition(h2.run_id, RunStatus.RUNNING)
+    registry.transition(h3.run_id, RunStatus.RUNNING)
+    registry.transition(h3.run_id, RunStatus.SUCCEEDED)
+
+    assert {h.run_id for h in registry.list()} == {h1.run_id, h2.run_id, h3.run_id}
+    assert [h.run_id for h in registry.list(RunStatus.RUNNING)] == [h2.run_id]
+    assert [h.run_id for h in registry.list(RunStatus.PENDING)] == [h1.run_id]
+    assert registry.list(RunStatus.FAILED) == []
+
+
+def test_list_returns_newest_first(registry: RunRegistry) -> None:
+    """Regression: the CLI ``ondine status`` shows the most recent run
+    first. If list returned oldest-first, the user would scroll past
+    stale jobs to find their latest one."""
+    ids = [registry.create(RunSpec(pipeline_id=str(uuid4()))).run_id for _ in range(3)]
+    listed = [h.run_id for h in registry.list()]
+    assert listed == list(reversed(ids))
+
+
+# ── regression #6: spec_snapshot round-trip ───────────────────────────
+
+
+def test_spec_snapshot_roundtrips_arbitrary_dict(registry: RunRegistry) -> None:
+    """Regression: the spec snapshot is what resume relies on — without
+    it, a crashed ``provider_batch`` run could not be reattached by the
+    CLI. Losing nested keys would silently drop the prompt/model."""
+    snapshot = {
+        "pipeline_id": str(uuid4()),
+        "model": "gpt-4o-mini",
+        "prompt": "Summarize: {text}",
+        "nested": {"batch_size": 32, "columns": ["a", "b"]},
+    }
+    handle = registry.create(RunSpec.from_dict({"spec_snapshot": snapshot}))
+
+    fresh = registry.get(handle.run_id)
+    assert fresh.spec_snapshot == snapshot
+    assert fresh.spec_snapshot["nested"]["columns"] == ["a", "b"]
+
+
+# ── regression #7: Pipeline.execute(run_id=...) integration ──────────
+
+
+def _make_pipeline(
+    checkpoint_dir: Path,
+    *,
+    failing: bool = False,
+) -> tuple[Any, PipelineSpecifications, Any]:
+    """Build a minimal Pipeline with a mocked LLM client.
+
+    The mock returns deterministic responses so execute() succeeds
+    without network access — we only need the registry wire-up, not the
+    LLM behaviour (which has its own test suite).
+
+    When ``failing=True`` the mock client raises on every invoke and the
+    processing spec uses ``ErrorPolicy.FAIL`` so the error propagates
+    out of execute(). This exercises the real failure path instead of
+    inventing a ``fail_fast`` knob that would just shadow ErrorPolicy.
+    """
+    from unittest.mock import patch
+
+    from ondine.adapters.llm_client import LLMClient
+    from ondine.api.pipeline import Pipeline
+    from ondine.core.models import LLMResponse
+    from ondine.core.specifications import ErrorPolicy, ProcessingSpec
+
+    df = pd.DataFrame({"text": ["a", "b", "c"]})
+    processing = ProcessingSpec(
+        checkpoint_dir=checkpoint_dir,
+        cleanup_on_success=False,
+        progress_mode="none",
+        max_retries=0,
+        retry_delay=0.0,
+    )
+    if failing:
+        processing = processing.model_copy(update={"error_policy": ErrorPolicy.FAIL})
+
+    specs = PipelineSpecifications(
+        dataset=DatasetSpec(
+            source_type=DataSourceType.DATAFRAME,
+            input_columns=["text"],
+            output_columns=["result"],
+        ),
+        prompt=PromptSpec(template="{text}"),
+        llm=LLMSpec(
+            provider=LLMProvider.OPENAI,
+            model="gpt-4o-mini",
+            input_cost_per_1k_tokens=Decimal("0.00015"),
+            output_cost_per_1k_tokens=Decimal("0.0006"),
+        ),
+        processing=processing,
+    )
+
+    if failing:
+
+        class FailingClient(LLMClient):
+            def invoke(self, prompt, **kwargs):
+                raise RuntimeError("simulated provider failure")
+
+            async def ainvoke(self, prompt, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            def structured_invoke(self, prompt, output_cls, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            async def structured_invoke_async(self, prompt, output_cls, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            async def start(self):
+                pass
+
+            async def stop(self):
+                pass
+
+            def estimate_tokens(self, text):
+                return len(text) // 4
+
+        mock_client = FailingClient(specs.llm)
+    else:
+
+        class MockClient(LLMClient):
+            def invoke(self, prompt, **kwargs):
+                return LLMResponse(
+                    text="ok",
+                    tokens_in=1,
+                    tokens_out=1,
+                    model=self.model,
+                    cost=Decimal("0.0001"),
+                    latency_ms=1.0,
+                )
+
+            async def ainvoke(self, prompt, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            def structured_invoke(self, prompt, output_cls, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            async def structured_invoke_async(self, prompt, output_cls, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            async def start(self):
+                pass
+
+            async def stop(self):
+                pass
+
+            def estimate_tokens(self, text):
+                return len(text) // 4
+
+        mock_client = MockClient(specs.llm)
+
+    pipeline = Pipeline(specs, dataframe=df)
+    patcher = patch(
+        "ondine.api.pipeline.create_llm_client",
+        return_value=mock_client,
+    )
+    patcher.start()
+    return pipeline, specs, patcher
+
+
+def test_pipeline_execute_with_run_id_registers_and_traces(
+    tmp_path: Path,
+) -> None:
+    """Regression: ``Pipeline.execute(run_id=...)`` must register the run
+    and trace its terminal state in the registry. Without the wire-up,
+    the MCP ``ondine_status`` tool would return PENDING forever for a
+    run that actually finished — a broken dashboard."""
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+    registry = RunRegistry(checkpoint_dir)
+    spec = RunSpec(
+        pipeline_id=str(uuid4()),
+        dataset="df",
+        spec_snapshot={"model": "gpt-4o-mini"},
+    )
+    handle = registry.create(spec)
+
+    pipeline, _, patcher = _make_pipeline(checkpoint_dir)
+    try:
+        pipeline.execute(run_id=handle.run_id, registry=registry)
+    finally:
+        patcher.stop()
+
+    final = registry.get(handle.run_id)
+    assert final is not None
+    assert final.status is RunStatus.SUCCEEDED
+    assert final.metrics["total_rows"] == 3
+
+
+def test_pipeline_execute_without_run_id_leaves_registry_empty(
+    tmp_path: Path,
+) -> None:
+    """Regression: the default path (run_id=None) must NOT touch the
+    registry. Existing users who never opted in would otherwise find a
+    ``runs.db`` file appearing in their checkpoint dir — a breaking
+    side-effect on every execute() call."""
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+    registry = RunRegistry(checkpoint_dir)
+
+    pipeline, _, patcher = _make_pipeline(checkpoint_dir)
+    try:
+        pipeline.execute()
+    finally:
+        patcher.stop()
+
+    registry2 = RunRegistry(checkpoint_dir)
+    try:
+        assert registry2.list() == []
+    finally:
+        registry.close()
+        registry2.close()
+
+
+def test_pipeline_execute_failure_records_failed_state(
+    tmp_path: Path,
+) -> None:
+    """Regression: when the pipeline raises, the registry must record
+    FAILED so the dashboard doesn't keep a dead run as RUNNING —
+    otherwise operators never know it died.
+
+    We exercise the real failure path: a mock LLM client that raises and
+    an ``ErrorPolicy.FAIL`` processing spec, so the error propagates out
+    of execute() exactly as a genuine provider outage would.
+    """
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+    registry = RunRegistry(checkpoint_dir)
+    spec = RunSpec(pipeline_id=str(uuid4()), dataset="df")
+    handle = registry.create(spec)
+
+    pipeline, _, patcher = _make_pipeline(checkpoint_dir, failing=True)
+    try:
+        with pytest.raises(Exception):
+            pipeline.execute(run_id=handle.run_id, registry=registry)
+    finally:
+        patcher.stop()
+
+    final = registry.get(handle.run_id)
+    assert final is not None
+    assert final.status is RunStatus.FAILED
+
+
+# ── fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> RunRegistry:
+    db_path = tmp_path / "runs.db"
+    r = RunRegistry(db_path)
+    yield r
+    r.close()


### PR DESCRIPTION
Persistent job index for pipeline runs. SQLite-backed (WAL mode), crash-safe.
Provides create/get/list/transition ops + RegistryObserver for live progress.
Pipeline.execute(run_id=...) registers itself (zero breaking change).
Tests: 17/17 pass. Merge order: 2nd.