### PR TITLE
feat(mcp): add FastMCP 3.x server with 4 ondine tools

### DIFF
--- a/ondine/api/pipeline.py
+++ b/ondine/api/pipeline.py
@@ -39,6 +39,8 @@ from ondine.orchestration import (
     ExecutionStrategy,
     LoggingObserver,
     ProgressBarObserver,
+    RunRegistry,
+    RunStatus,
     StateManager,
     StreamingExecutor,
     SyncExecutor,
@@ -239,7 +241,13 @@ class Pipeline:
             confidence="sample-based",
         )
 
-    def execute(self, resume_from: UUID | None = None) -> ExecutionResult:
+    def execute(
+        self,
+        resume_from: UUID | None = None,
+        *,
+        run_id: UUID | None = None,
+        registry: "RunRegistry | None" = None,
+    ) -> ExecutionResult:
         """
         Execute pipeline end-to-end.
 
@@ -248,6 +256,12 @@ class Pipeline:
 
         Args:
             resume_from: Optional session ID to resume from checkpoint (for fault tolerance)
+            run_id: Optional run registry ID. When provided alongside ``registry``,
+                the run is traced through PENDING -> RUNNING -> SUCCEEDED|FAILED in
+                the registry so external observers (CLI, MCP) can follow progress.
+                Default ``None`` leaves behaviour unchanged — no registry artifact.
+            registry: Optional :class:`~ondine.orchestration.RunRegistry`. Required
+                when ``run_id`` is set; ignored otherwise.
 
         Returns:
             ExecutionResult containing:
@@ -378,6 +392,18 @@ class Pipeline:
         for observer in self.observers:
             observer.on_pipeline_start(self, context)
 
+        # Trace the run in the registry if the caller opted in. We move
+        # PENDING -> RUNNING now so a crash after this line still leaves
+        # a durable RUNNING record for the CLI/MCP to report. The
+        # terminal transition (SUCCEEDED/FAILED) is recorded below.
+        if run_id is not None and registry is not None:
+            try:
+                registry.transition(run_id, RunStatus.RUNNING)
+            except Exception as reg_err:  # noqa: BLE001
+                self.logger.warning(
+                    f"RunRegistry transition to RUNNING failed for {run_id}: {reg_err}"
+                )
+
         try:
             # Execute stages (preprocessing happens inside if enabled)
             result_df = self._execute_stages(context, state_manager)
@@ -473,6 +499,27 @@ class Pipeline:
             if tracker_ref is not None:
                 tracker_ref.show_summary(result)
 
+            # Record terminal success in the registry. We snapshot the
+            # row count and cost so the MCP ``ondine_status`` tool can
+            # report final figures without re-reading the result object.
+            if run_id is not None and registry is not None:
+                try:
+                    registry.transition(
+                        run_id,
+                        RunStatus.SUCCEEDED,
+                        metrics={
+                            "total_rows": int(context.total_rows),
+                            "processed_rows": int(result.metrics.processed_rows),
+                            "failed_rows": int(result.metrics.failed_rows),
+                            "cost": str(result.costs.total_cost),
+                        },
+                    )
+                except Exception as reg_err:  # noqa: BLE001
+                    self.logger.warning(
+                        f"RunRegistry transition to SUCCEEDED failed "
+                        f"for {run_id}: {reg_err}"
+                    )
+
             return result
 
         except KeyboardInterrupt:
@@ -491,6 +538,25 @@ class Pipeline:
                 f"Pipeline failed. Checkpoint saved. "
                 f"Resume with: pipeline.execute(resume_from=UUID('{context.session_id}'))"
             )
+
+            # Record terminal failure in the registry before re-raising.
+            # An operator polling ``ondine status`` must see FAILED, not a
+            # stale RUNNING — otherwise dead runs haunt the dashboard.
+            if run_id is not None and registry is not None:
+                try:
+                    registry.transition(
+                        run_id,
+                        RunStatus.FAILED,
+                        metrics={
+                            "total_rows": int(context.total_rows),
+                            "error": f"{type(e).__name__}: {e}",
+                        },
+                    )
+                except Exception as reg_err:  # noqa: BLE001
+                    self.logger.warning(
+                        f"RunRegistry transition to FAILED failed "
+                        f"for {run_id}: {reg_err}"
+                    )
 
             # Notify legacy observers of error
             for observer in self.observers:

--- a/ondine/mcp/__init__.py
+++ b/ondine/mcp/__init__.py
@@ -1,0 +1,25 @@
+"""Ondine MCP server (L5 front door).
+
+Exposes four pipeline operations as MCP tools (ondine_estimate, ondine_run,
+ondine_status, ondine_collect). Requires the ``ondine[mcp]`` extra (FastMCP).
+See :mod:`ondine.mcp.server` for the implementation.
+"""
+
+from ondine.mcp.progress import RegistryProgressObserver
+
+
+def __getattr__(name: str):
+    # Lazy: importing the package does not require fastmcp; only building the
+    # server does. This keeps `import ondine.mcp` cheap and dep-free.
+    if name == "MCPService":
+        from ondine.mcp.server import MCPService
+
+        return MCPService
+    if name == "create_server":
+        from ondine.mcp.server import create_server
+
+        return create_server
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["MCPService", "create_server", "RegistryProgressObserver"]

--- a/ondine/mcp/progress.py
+++ b/ondine/mcp/progress.py
@@ -1,0 +1,130 @@
+"""Bridge from pipeline execution progress to the RunRegistry.
+
+The MCP ``ondine_status`` tool needs live rows-done and cost-so-far for a
+RUNNING job. That data flows through :class:`ExecutionContext` during
+execution; this module is the :class:`ExecutionObserver` that copies the
+relevant counters onto the durable :class:`RunRegistry` row so a status poller
+(even in another process) sees them.
+
+Design (information hiding):
+
+* The observer knows two things: which ``run_id`` it serves, and which
+  registry to write to. It does not know what a "stage" is, how cost is
+  accumulated, or what transport reads it back. It is a pure forwarder.
+* Writes are best-effort and throttled: progress churns on every batch, and a
+  registry write per batch would be needlessly expensive and would spam the
+  WAL. A minimum interval between writes collapses the burst while keeping
+  status fresh enough for human-scale polling.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from ondine.orchestration.observers import ExecutionObserver
+
+if TYPE_CHECKING:
+    from ondine.orchestration.execution_context import ExecutionContext
+    from ondine.orchestration.run_registry import RunRegistry
+    from ondine.stages.pipeline_stage import PipelineStage
+
+
+class RegistryProgressObserver(ExecutionObserver):
+    """Forward live execution progress to a RunRegistry row.
+
+    Attached to a :class:`~ondine.api.pipeline.Pipeline` via
+    ``pipeline.add_observer(...)`` before ``execute(run_id=..., registry=...)``.
+    On every progress update it writes ``processed_rows`` and ``cost`` to the
+    registry under ``run_id`` using :meth:`RunRegistry.update_metrics`, which
+    persists without changing status (status transitions are the pipeline's
+    job).
+
+    Throttling: writes are collapsed to at most one per ``min_interval``
+    seconds (default 0.25s) so a fast run does not write the WAL on every row.
+    """
+
+    def __init__(
+        self,
+        registry: RunRegistry,
+        run_id: Any,
+        min_interval: float = 0.25,
+    ) -> None:
+        self._registry = registry
+        self._run_id = run_id
+        self._min_interval = min_interval
+        self._last_write: float = 0.0
+        self._last_rows: int = -1
+
+    # ── ExecutionObserver interface ─────────────────────────────────
+
+    def on_pipeline_start(self, pipeline: Any, context: ExecutionContext) -> None:
+        self._flush(context)
+
+    def on_stage_start(self, stage: PipelineStage, context: ExecutionContext) -> None:
+        pass  # progress is reported via on_progress_update / on_stage_complete
+
+    def on_stage_complete(
+        self, stage: PipelineStage, context: ExecutionContext, result: Any
+    ) -> None:
+        self._flush(context)
+
+    def on_stage_error(
+        self,
+        stage: PipelineStage,
+        context: ExecutionContext,
+        error: Exception,
+    ) -> None:
+        self._flush(context)
+
+    def on_pipeline_complete(self, context: ExecutionContext, result: Any) -> None:
+        # Final flush with the authoritative end state — bypass the throttle.
+        self._write(
+            processed_rows=int(getattr(context, "last_processed_row", 0)),
+            total_rows=int(getattr(context, "total_rows", 0)),
+            cost=context.run_progress.snapshot_cost,
+            force=True,
+        )
+
+    def on_pipeline_error(self, context: ExecutionContext, error: Exception) -> None:
+        self._flush(context, force=True)
+
+    def on_progress_update(self, context: ExecutionContext) -> None:
+        self._flush(context)
+
+    # ── internals ───────────────────────────────────────────────────
+
+    def _flush(self, context: ExecutionContext, force: bool = False) -> None:
+        rows = int(getattr(context, "last_processed_row", 0))
+        # Skip if rows haven't advanced since the last write (no new info).
+        if not force and rows == self._last_rows:
+            return
+        self._write(
+            processed_rows=rows,
+            total_rows=int(getattr(context, "total_rows", 0)),
+            cost=context.run_progress.snapshot_cost,
+            force=force,
+        )
+
+    def _write(
+        self,
+        processed_rows: int,
+        total_rows: int,
+        cost: Any,
+        force: bool = False,
+    ) -> None:
+        now = time.monotonic()
+        if not force and (now - self._last_write) < self._min_interval:
+            return
+        self._last_write = now
+        self._last_rows = processed_rows
+        metrics: dict[str, Any] = {"processed_rows": processed_rows, "cost": str(cost)}
+        if total_rows:
+            metrics["total_rows"] = total_rows
+        try:
+            self._registry.update_metrics(self._run_id, metrics)
+        except Exception:  # noqa: BLE001
+            # A registry write failure must never kill the run. The terminal
+            # transition (written by Pipeline.execute) is the source of truth
+            # for final state; live-progress writes are best-effort.
+            pass

--- a/ondine/mcp/server.py
+++ b/ondine/mcp/server.py
@@ -1,0 +1,473 @@
+"""ondine MCP server — an L5 front door exposing pipeline ops as MCP tools.
+
+Architecture (see /plans/ARCHITECTURE_PROPOSAL.md §4):
+
+* This module sits at L5 (front door). It imports only L4 (Pipeline) and
+  ondine.config — never stages or engines. The four tools are thin façades.
+* ``ondine_run`` hands back a ``run_id`` immediately and runs the pipeline on a
+  daemon thread, writing progress to the shared RunRegistry (§2). A second
+  tool call (``ondine_status`` / ``ondine_collect``) — even from another
+  process — reads the durable registry row to report live progress and final
+  results.
+* A budget cap is MANDATORY on every ``ondine_run``: the whole point of
+  exposing dataset processing to an LLM tool client is that the caller may not
+  understand the cost implications, so the server refuses to launch without an
+  explicit ceiling and injects it into the processing spec so the engine's own
+  BudgetController enforces it end-to-end.
+
+The MCP wire layer (FastMCP 3.x) is a pass-through: ``create_server()`` decorates
+the four ``MCPService`` methods and returns the app; all behaviour lives in
+:class:`MCPService` so it is directly unit-testable without an MCP client.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from decimal import Decimal
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from ondine.api.pipeline import Pipeline
+from ondine.config.config_loader import ConfigLoader
+from ondine.mcp.progress import RegistryProgressObserver
+from ondine.utils import get_logger
+from ondine.utils.optional_dependencies import _matches_missing_dependency
+
+if TYPE_CHECKING:
+    from ondine.orchestration.run_registry import (
+        RunHandle,
+        RunRegistry,
+        RunStatus,
+    )
+
+logger = get_logger(__name__)
+
+
+def _require_fastmcp() -> Any:
+    """Import FastMCP lazily so importing this module never forces the extra.
+
+    The ``ondine[mcp]`` extra installs ``fastmcp``; users who never run the
+    server should not pay the import cost or see an import error. This helper
+    raises a clear, actionable error pointing at the extra on missing dep.
+    """
+    try:
+        from fastmcp import FastMCP
+    except ImportError as exc:
+        if _matches_missing_dependency(exc, ("fastmcp", "mcp")):
+            raise ImportError(
+                "The ondine MCP server requires the 'mcp' extra. "
+                "Install with: pip install 'ondine[mcp]'"
+            ) from exc
+        raise
+    return FastMCP
+
+
+class MCPService:
+    """Plain-Python implementation of the four MCP tools.
+
+    Every method maps 1:1 to an MCP tool (``ondine_estimate`` →
+    :meth:`ondine_estimate`, etc.). Keeping the logic in a transport-agnostic
+    class means the behaviour is fully testable without spinning up an MCP
+    client, and the FastMCP layer in :func:`create_server` is a trivial
+    decorator pass-through.
+
+    State held across calls:
+
+    * ``_registry`` — the shared :class:`RunRegistry` (§2). This is the
+      cross-call (and cross-process) channel for run identity, status, and
+      live progress. It is the *only* durable state the service owns.
+    * ``_threads`` — in-process background workers keyed by run_id. v1 runs
+      jobs on a daemon thread of the server process; the registry's on-disk
+      row means a crash or restart still leaves a resumable checkpoint and a
+      discoverable run_id. True out-of-process workers are §3's scope.
+    """
+
+    def __init__(
+        self,
+        registry_dir: str | Path | None = None,
+        registry: RunRegistry | None = None,
+    ) -> None:
+        if registry is not None:
+            self._registry = registry
+            self._owns_registry = False
+        else:
+            from ondine.orchestration.run_registry import RunRegistry
+
+            reg_dir = (
+                Path(registry_dir) if registry_dir is not None else Path(".checkpoints")
+            )
+            reg_dir.mkdir(parents=True, exist_ok=True)
+            self._registry = RunRegistry(reg_dir)
+            self._owns_registry = True
+        self._threads: dict[str, threading.Thread] = {}
+
+    # ── ondine_estimate ─────────────────────────────────────────────
+
+    def ondine_estimate(
+        self,
+        config_yaml: str,
+        sample_rows: int | None = None,
+    ) -> dict[str, Any]:
+        """Estimate cost/token/row counts for a config WITHOUT running.
+
+        Side-effect-free: builds a Pipeline purely to call ``estimate_cost()``,
+        never touches the registry and never writes a checkpoint.
+        """
+        pipeline = self._build_pipeline(config_yaml)
+        estimate = pipeline.estimate_cost()
+        return {
+            "total_cost": str(estimate.total_cost),
+            "total_tokens": estimate.total_tokens,
+            "input_tokens": estimate.input_tokens,
+            "output_tokens": estimate.output_tokens,
+            "rows": estimate.rows,
+            "confidence": estimate.confidence,
+        }
+
+    # ── ondine_run ──────────────────────────────────────────────────
+
+    def ondine_run(
+        self,
+        config_yaml: str,
+        input_path: str,
+        output_path: str,
+        budget: float | Decimal | str | None,
+    ) -> dict[str, Any]:
+        """Launch a pipeline run, returning ``run_id`` immediately.
+
+        ``budget`` is MANDATORY and must be positive — an LLM tool client must
+        not be able to launch an unbounded-spend job. The budget is injected
+        into the processing spec so the engine's BudgetController enforces it,
+        and persisted in the run's spec snapshot for audit.
+        """
+        budget_decimal = self._require_positive_budget(budget)
+
+        pipeline = self._build_pipeline(config_yaml)
+        # Inject the mandatory budget into the spec the engine will actually
+        # run, so the BudgetController caps spend at the source.
+        pipeline.specifications.processing.max_budget = budget_decimal
+
+        # Override I/O paths from the tool arguments (they are the source of
+        # truth for an MCP call, superseding whatever the YAML carried).
+        pipeline.specifications.dataset.source_path = Path(input_path)
+        self._apply_output(pipeline, Path(output_path))
+
+        # Register the run BEFORE launching so the id is durable even if the
+        # worker thread fails to start. The snapshot carries the budget for
+        # audit and the input/output paths for collect().
+        spec_snapshot = pipeline.specifications.model_dump(mode="json")
+        spec_snapshot.setdefault("_mcp", {})
+        spec_snapshot["_mcp"].update(
+            {"input_path": str(input_path), "output_path": str(output_path)}
+        )
+        from ondine.orchestration.run_registry import RunSpec
+
+        run_spec = RunSpec(
+            pipeline_id=str(pipeline.id),
+            dataset=str(input_path),
+            spec_snapshot=spec_snapshot,
+        )
+        handle = self._registry.create(run_spec)
+        run_id_str = str(handle.run_id)
+
+        # Wire pipeline progress → registry so ondine_status sees live rows/cost.
+        pipeline.add_observer(RegistryProgressObserver(self._registry, handle.run_id))
+
+        # Run on a daemon thread: the call returns the run_id now; the thread
+        # drives the registry through RUNNING → SUCCEEDED|FAILED.
+        thread = threading.Thread(
+            target=self._run_worker,
+            name=f"ondine-mcp-{run_id_str[:8]}",
+            args=(pipeline, handle.run_id),
+            daemon=True,
+        )
+        self._threads[run_id_str] = thread
+        thread.start()
+        return {"run_id": run_id_str}
+
+    # ── ondine_status ───────────────────────────────────────────────
+
+    def ondine_status(self, run_id: str) -> dict[str, Any]:
+        """Live status: state, progress %, rows done, cost so far."""
+        handle = self._registry.get(_to_uuid(run_id))
+        if handle is None:
+            raise KeyError(f"Unknown run_id: {run_id}")
+        metrics = handle.metrics or {}
+        total = metrics.get("total_rows", 0) or 0
+        done = metrics.get("processed_rows", metrics.get("rows_done", 0)) or 0
+        progress_pct = (done / total * 100) if total else 0.0
+        return {
+            "run_id": str(handle.run_id),
+            "status": handle.status.value,
+            "progress_pct": round(progress_pct, 2),
+            "rows_done": done,
+            "total_rows": total,
+            "cost": str(metrics.get("cost", "0")),
+            "updated_at": handle.updated_at,
+        }
+
+    # ── ondine_collect ──────────────────────────────────────────────
+
+    def ondine_collect(self, run_id: str) -> dict[str, Any]:
+        """Terminal readout: rows, cost, and the output path.
+
+        Refuses a non-terminal run so a caller never gets a half-written
+        summary. Use :meth:`ondine_status` to follow an in-flight run.
+        """
+        handle = self._registry.get(_to_uuid(run_id))
+        if handle is None:
+            raise KeyError(f"Unknown run_id: {run_id}")
+        if handle.status.value not in ("succeeded", "failed", "partial"):
+            raise ValueError(
+                f"Run {run_id} is not finished (status={handle.status.value}); "
+                "poll ondine_status until terminal."
+            )
+        metrics = handle.metrics or {}
+        mcp_meta = (handle.spec_snapshot or {}).get("_mcp", {})
+        output_path = mcp_meta.get("output_path") or metrics.get("output_path", "")
+        return {
+            "run_id": str(handle.run_id),
+            "status": handle.status.value,
+            "rows_done": metrics.get("processed_rows", metrics.get("rows_done", 0)),
+            "total_rows": metrics.get("total_rows", 0),
+            "cost": str(metrics.get("cost", "0")),
+            "output_path": str(output_path),
+            "error": metrics.get("error"),
+            "updated_at": handle.updated_at,
+        }
+
+    # ── convenience / test seams ────────────────────────────────────
+
+    def list_runs(self) -> list[RunHandle]:
+        """List all known runs (newest-first), for inspection/testing."""
+        return self._registry.list()
+
+    def get_spec_snapshot(self, run_id: str) -> dict[str, Any] | None:
+        handle = self._registry.get(_to_uuid(run_id))
+        return dict(handle.spec_snapshot) if handle is not None else None
+
+    def wait_and_collect(self, run_id: str, timeout: float = 60.0) -> dict[str, Any]:
+        """Block until the run is terminal, then return :meth:`ondine_collect`.
+
+        Convenience for tests and synchronous callers; the MCP tool itself
+        never blocks (ondine_run returns immediately).
+        """
+        import time
+
+        uid = _to_uuid(run_id)
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            handle = self._registry.get(uid)
+            if handle is not None and handle.status.value in (
+                "succeeded",
+                "failed",
+                "partial",
+            ):
+                return self.ondine_collect(run_id)
+            time.sleep(0.05)
+        raise TimeoutError(f"Run {run_id} did not finish within {timeout}s")
+
+    def _seed_pending_run(self) -> RunHandle:
+        """Create a PENDING run with no worker — a test seam for asserting
+        that ondine_collect refuses an in-flight run."""
+        from ondine.orchestration.run_registry import RunSpec
+
+        return self._registry.create(RunSpec(pipeline_id="test-seed", dataset="seed"))
+
+    def close(self) -> None:
+        if self._owns_registry:
+            self._registry.close()
+
+    # ── internals ───────────────────────────────────────────────────
+
+    @staticmethod
+    def _require_positive_budget(
+        budget: float | Decimal | str | None,
+    ) -> Decimal:
+        if budget is None:
+            raise ValueError(
+                "A budget cap is mandatory for ondine_run. Pass a positive "
+                "budget (USD) to set the maximum spend for this run."
+            )
+        try:
+            dec = Decimal(str(budget))
+        except Exception as exc:  # noqa: BLE001
+            raise ValueError(f"Budget must be a number, got {budget!r}") from exc
+        if dec <= 0:
+            raise ValueError(
+                f"Budget must be positive (got {dec}); an MCP run cannot be "
+                "launched without a spend ceiling."
+            )
+        return dec
+
+    @staticmethod
+    def _build_pipeline(config_yaml: str) -> Pipeline:
+        """Parse a YAML/JSON config string into a Pipeline (no execution).
+
+        Reuses ConfigLoader so MCP and CLI accept identical config shapes.
+        """
+        config_dict = yaml.safe_load(config_yaml)
+        if not isinstance(config_dict, dict):
+            raise ValueError(
+                "config_yaml must parse to a mapping (dict); got "
+                f"{type(config_dict).__name__}"
+            )
+        specs = ConfigLoader._dict_to_specifications(config_dict)  # noqa: SLF001
+        return Pipeline(specs)
+
+    @staticmethod
+    def _apply_output(pipeline: Pipeline, output_path: Path) -> None:
+        from ondine.core.specifications import (
+            DataSourceType,
+            MergeStrategy,
+            OutputSpec,
+        )
+
+        suffix = output_path.suffix.lower()
+        dst_type = {
+            ".csv": DataSourceType.CSV,
+            ".json": DataSourceType.CSV,
+            ".parquet": DataSourceType.PARQUET,
+            ".xlsx": DataSourceType.EXCEL,
+            ".xls": DataSourceType.EXCEL,
+        }.get(suffix, DataSourceType.CSV)
+        pipeline.specifications.output = OutputSpec(
+            destination_type=dst_type,
+            destination_path=output_path,
+            merge_strategy=MergeStrategy.REPLACE,
+        )
+
+    def _run_worker(self, pipeline: Pipeline, run_id: uuid.UUID) -> None:
+        """Background worker: drive the registry through the run lifecycle.
+
+        Errors are swallowed here (and recorded as FAILED in the registry by
+        Pipeline.execute itself) so a failing worker never crashes the server
+        process or leaves the thread pool in a bad state.
+        """
+
+        # Re-derive total rows for progress math before execute mutates state.
+        try:
+            loader_df = pipeline.dataframe
+            if loader_df is None and pipeline.specifications.dataset.source_path:
+                import pandas as pd
+
+                loader_df = pd.read_csv(pipeline.specifications.dataset.source_path)
+            total_rows = int(len(loader_df)) if loader_df is not None else 0
+            self._registry.update_metrics(run_id, {"total_rows": total_rows})
+        except Exception:  # noqa: BLE001
+            # Non-fatal: progress % will just read 0 total until the observer
+            # writes the real count. Don't block the run on row-count math.
+            pass
+
+        try:
+            pipeline.execute(run_id=run_id, registry=self._registry)
+        except Exception as exc:  # noqa: BLE001
+            # Pipeline.execute already recorded FAILED in the registry; this
+            # guard is for failures in the thread plumbing itself.
+            logger.exception("ondine_run worker for %s crashed", run_id)
+            try:
+                self._registry.transition(
+                    run_id,
+                    self._terminal_for(run_id),
+                    metrics={"error": f"{type(exc).__name__}: {exc}"},
+                )
+            except Exception:  # noqa: BLE001
+                pass
+        finally:
+            self._threads.pop(str(run_id), None)
+
+    def _terminal_for(self, run_id: uuid.UUID) -> RunStatus:
+        """Pick a legal terminal status from the run's current state."""
+        from ondine.orchestration.run_registry import RunStatus
+
+        handle = self._registry.get(run_id)
+        if handle is not None and handle.status is RunStatus.PENDING:
+            return RunStatus.FAILED  # PENDING can only move to RUNNING or FAILED
+        return RunStatus.FAILED
+
+
+def _to_uuid(run_id: str) -> uuid.UUID:
+    try:
+        return uuid.UUID(str(run_id))
+    except (ValueError, TypeError) as exc:
+        raise KeyError(f"Invalid run_id (not a UUID): {run_id!r}") from exc
+
+
+def create_server(service: MCPService | None = None) -> Any:
+    """Build the FastMCP app with the four ondine tools registered.
+
+    Returns the FastMCP instance; call ``.run()`` (stdio) to serve. Importing
+    this function does not import FastMCP — only calling it does — so users
+    without the ``ondine[mcp]`` extra can still import the rest of ondine.
+    """
+    fastmcp_cls = _require_fastmcp()
+    svc = service if service is not None else MCPService()
+    mcp = fastmcp_cls("ondine")
+
+    @mcp.tool(
+        name="ondine_estimate",
+        description=(
+            "Estimate the cost, token usage, and row count for an ondine "
+            "pipeline configuration WITHOUT running it. Fast and side-effect "
+            "-free. Pass the full config as a YAML string."
+        ),
+    )
+    def _estimate(
+        config_yaml: str,
+        sample_rows: int | None = None,
+    ) -> dict[str, Any]:
+        return svc.ondine_estimate(config_yaml, sample_rows)
+
+    @mcp.tool(
+        name="ondine_run",
+        description=(
+            "Launch an ondine pipeline run. Returns run_id immediately — the "
+            "job runs in the background; poll ondine_status for progress and "
+            "call ondine_collect once it finishes. A positive budget (USD) is "
+            "MANDATORY and caps total spend."
+        ),
+    )
+    def _run(
+        config_yaml: str,
+        input_path: str,
+        output_path: str,
+        budget: float,
+    ) -> dict[str, Any]:
+        return svc.ondine_run(config_yaml, input_path, output_path, budget)
+
+    @mcp.tool(
+        name="ondine_status",
+        description=(
+            "Poll the live status of an ondine run: state, progress %, rows "
+            "done, and cost so far. Returns 'unknown run_id' if the id was "
+            "never created."
+        ),
+    )
+    def _status(run_id: str) -> dict[str, Any]:
+        return svc.ondine_status(run_id)
+
+    @mcp.tool(
+        name="ondine_collect",
+        description=(
+            "Collect the final result of a finished ondine run: rows, cost, "
+            "the output file path, and any error. Refuses a still-running run "
+            "(poll ondine_status first)."
+        ),
+    )
+    def _collect(run_id: str) -> dict[str, Any]:
+        return svc.ondine_collect(run_id)
+
+    return mcp
+
+
+def main() -> None:
+    """Console-script entrypoint: ``ondine-mcp`` serves over stdio."""
+    server = create_server()
+    server.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/ondine/orchestration/__init__.py
+++ b/ondine/orchestration/__init__.py
@@ -22,6 +22,14 @@ from ondine.orchestration.progress_tracker import (
     RichProgressTracker,
     create_progress_tracker,
 )
+from ondine.orchestration.run_registry import (
+    REGISTRY_FILENAME,
+    RegistryObserver,
+    RunHandle,
+    RunRegistry,
+    RunSpec,
+    RunStatus,
+)
 from ondine.orchestration.state_manager import StateManager
 from ondine.orchestration.streaming_executor import (
     StreamingExecutor,
@@ -56,6 +64,13 @@ __all__ = [
     "ConcurrencyController",
     "DeploymentTracker",
     "ProgressReporter",
+    # Run registry — persistent cross-process job index
+    "RunRegistry",
+    "RunHandle",
+    "RunSpec",
+    "RunStatus",
+    "RegistryObserver",
+    "REGISTRY_FILENAME",
     # Streaming processing (for large datasets)
     "StreamingProcessor",
     "StreamingStats",

--- a/ondine/orchestration/run_registry.py
+++ b/ondine/orchestration/run_registry.py
@@ -1,0 +1,483 @@
+"""Persistent job index for pipeline runs.
+
+The RunRegistry is the single source of truth for the lifetime of a run
+across process boundaries. The MCP ``ondine_run`` tool hands out a
+``run_id`` immediately; a worker process (or a later CLI invocation)
+resolves that same id against the on-disk SQLite database. Because the
+whole point is crash-safe durability, the registry is backed by a real
+SQLite file with WAL mode — never an in-memory mock.
+
+Design (deep module, information hiding):
+
+* ``RunRegistry`` exposes four operations — ``create``, ``get``,
+  ``list``, ``transition`` — and hides every SQL statement, schema
+  migration, and serialisation detail behind them.
+* ``RunHandle`` is an immutable snapshot read fresh from disk on every
+  ``get``/``list``/``transition`` call. There is deliberately no
+  in-memory cache: a second process polling status must see the
+  latest committed row, so caching would be a bug, not an optimisation.
+* ``RegistryObserver`` is the extension point for live progress feeds
+  (the MCP status stream). Observers are notified inside the same
+  transaction commit so a crash between "persist" and "notify" is
+  impossible.
+
+The registry is optional. ``Pipeline.execute(run_id=None)`` (the
+default) never touches it, so existing users see no new on-disk artefact.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from abc import ABC, abstractmethod
+from enum import Enum
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+from ondine.utils import get_logger
+
+logger = get_logger(__name__)
+
+# Sentinel filename inside the checkpoint directory. Co-located with
+# checkpoints and the response cache so that copying the checkpoint dir
+# also carries the run history — one artefact to back up.
+REGISTRY_FILENAME = "runs.db"
+
+
+class RunStatus(str, Enum):
+    """Lifecycle states for a single pipeline run.
+
+    The ordering encodes the legal forward transitions (see
+    ``_ALLOWED_TRANSITIONS``). A run moves strictly forward; there is no
+    "un-fail" path. PARTIAL covers the ProviderBatch case where some
+    rows succeeded but the job did not complete cleanly.
+    """
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUBMITTED_REMOTE = "submitted_remote"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    PARTIAL = "partial"
+
+
+# Legal forward edges. Key = current status, value = statuses reachable
+# in one hop. Defined once, checked on every transition so the registry
+# can never record an impossible history (e.g. PENDING -> SUCCEEDED).
+_ALLOWED_TRANSITIONS: dict[RunStatus, frozenset[RunStatus]] = {
+    RunStatus.PENDING: frozenset({RunStatus.RUNNING, RunStatus.FAILED}),
+    RunStatus.RUNNING: frozenset(
+        {
+            RunStatus.SUBMITTED_REMOTE,
+            RunStatus.SUCCEEDED,
+            RunStatus.FAILED,
+            RunStatus.PARTIAL,
+        }
+    ),
+    RunStatus.SUBMITTED_REMOTE: frozenset(
+        {RunStatus.SUCCEEDED, RunStatus.FAILED, RunStatus.PARTIAL}
+    ),
+    # Terminal states have no outgoing edges.
+    RunStatus.SUCCEEDED: frozenset(),
+    RunStatus.FAILED: frozenset(),
+    RunStatus.PARTIAL: frozenset(),
+}
+
+
+class RegistryObserver(ABC):
+    """Extension point for status-transition events.
+
+    Implementations drive the live progress feed in the MCP server and
+    any metrics sinks. The registry calls ``on_transition`` exactly once
+    per committed transition, after the row is durable on disk. An
+    observer that raises cannot roll back the transition — the registry
+    logs and swallows the error so one misbehaving listener cannot take
+    down a run (mirrors ``ExecutionContext.notify_progress``).
+    """
+
+    @abstractmethod
+    def on_transition(self, run_id: UUID, old: RunStatus, new: RunStatus) -> None:
+        """Called after a status transition is committed to disk."""
+        raise NotImplementedError
+
+
+class RunSpec:
+    """User-supplied description of a run at creation time.
+
+    A thin value object: ``pipeline_id`` identifies which pipeline
+    configuration is running, ``dataset`` is a short label for the input
+    (a filename or ``"dataframe"``), and ``spec_snapshot`` is the
+    arbitrary JSON-serialisable dict that resume and the CLI rely on to
+    reconstruct the run. Everything serialises through ``to_dict`` /
+    ``from_dict`` so the registry never has to know the shape.
+    """
+
+    def __init__(
+        self,
+        pipeline_id: str,
+        dataset: str = "",
+        spec_snapshot: dict[str, Any] | None = None,
+    ) -> None:
+        self.pipeline_id = pipeline_id
+        self.dataset = dataset
+        # Default the snapshot to the identifying fields so that callers
+        # who only pass pipeline_id/dataset still get a useful, non-empty
+        # snapshot (the contract every test asserts on).
+        self.spec_snapshot = (
+            dict(spec_snapshot)
+            if spec_snapshot
+            else {
+                "pipeline_id": pipeline_id,
+                "dataset": dataset,
+            }
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pipeline_id": self.pipeline_id,
+            "dataset": self.dataset,
+            "spec_snapshot": self.spec_snapshot,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunSpec:
+        # Tolerate both the full serialised form and a bare snapshot
+        # (tests pass {"spec_snapshot": {...}} directly).
+        if "spec_snapshot" in data and "pipeline_id" not in data:
+            snapshot = data["spec_snapshot"]
+            return cls(
+                pipeline_id=snapshot.get("pipeline_id", str(uuid4())),
+                dataset=snapshot.get("dataset", ""),
+                spec_snapshot=snapshot,
+            )
+        return cls(
+            pipeline_id=data.get("pipeline_id", str(uuid4())),
+            dataset=data.get("dataset", ""),
+            spec_snapshot=data.get("spec_snapshot"),
+        )
+
+
+class RunHandle:
+    """Immutable, read-only view of a run's current on-disk state.
+
+    A handle is a snapshot, not a live cursor: re-fetch via
+    ``registry.get(run_id)`` to observe subsequent transitions. Keeping
+    it immutable means callers cannot drift the in-memory copy out of
+    sync with the database.
+    """
+
+    __slots__ = (
+        "run_id",
+        "status",
+        "spec_snapshot",
+        "metrics",
+        "provider_job_id",
+        "created_at",
+        "updated_at",
+    )
+
+    def __init__(
+        self,
+        run_id: UUID,
+        status: RunStatus,
+        spec_snapshot: dict[str, Any],
+        metrics: dict[str, Any],
+        provider_job_id: str | None,
+        created_at: str,
+        updated_at: str,
+    ) -> None:
+        self.run_id = run_id
+        self.status = status
+        self.spec_snapshot = spec_snapshot
+        self.metrics = metrics
+        self.provider_job_id = provider_job_id
+        self.created_at = created_at
+        self.updated_at = updated_at
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return (
+            f"RunHandle(run_id={self.run_id}, status={self.status.name}, "
+            f"provider_job_id={self.provider_job_id!r})"
+        )
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS runs (
+    run_id           TEXT PRIMARY KEY,
+    status           TEXT NOT NULL,
+    spec_snapshot    TEXT NOT NULL,
+    metrics          TEXT NOT NULL DEFAULT '{}',
+    provider_job_id  TEXT,
+    created_at       TEXT NOT NULL,
+    updated_at       TEXT NOT NULL
+);
+"""
+
+
+def _row_to_handle(row: sqlite3.Row) -> RunHandle:
+    return RunHandle(
+        run_id=UUID(row["run_id"]),
+        status=RunStatus(row["status"]),
+        spec_snapshot=json.loads(row["spec_snapshot"]),
+        metrics=json.loads(row["metrics"] or "{}"),
+        provider_job_id=row["provider_job_id"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+class RunRegistry:
+    """Crash-safe, on-disk index of pipeline runs.
+
+    The registry is a deep module: callers use ``create`` / ``get`` /
+    ``list`` / ``transition`` and never see SQL, the WAL pragma, or the
+    serialisation format. The database file lives in the existing
+    checkpoint directory (or any path the caller chooses), so there is
+    exactly one persistence location to back up.
+
+    Thread-safety: a module-level lock serialises writes so concurrent
+    threads in one process cannot interleave a transition with observer
+    dispatch. Cross-process safety comes from SQLite's own file locking.
+    """
+
+    # Process-wide lock. SQLite serialises cross-process writes, but
+    # observer dispatch must not be interrupted by a second in-process
+    # transition.
+    _write_lock = threading.Lock()
+
+    def __init__(self, path: Path | str) -> None:
+        """Open (or create) the registry at ``path``.
+
+        ``path`` may be either a directory (the registry file is created
+        inside it as ``runs.db``, co-located with checkpoints) or a
+        direct file path. A directory keeps every persistence artefact
+        in one place; a file path is convenient for tests and ad-hoc
+        tooling.
+        """
+        path = Path(path)
+        if path.is_dir() or (not path.exists() and path.suffix == ""):
+            # Treat as a directory: ensure it exists, then nest the db.
+            path.mkdir(parents=True, exist_ok=True)
+            self._db_path = path / REGISTRY_FILENAME
+        else:
+            self._db_path = path
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self._conn = sqlite3.connect(
+            str(self._db_path),
+            isolation_level=None,  # autocommit; we manage txns explicitly
+            check_same_thread=False,
+        )
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._conn.executescript(_SCHEMA)
+        self._observers: list[RegistryObserver] = []
+
+    # ── observers ──────────────────────────────────────────────────
+
+    def add_observer(self, observer: RegistryObserver) -> None:
+        """Register an observer for status-transition events."""
+        self._observers.append(observer)
+
+    def remove_observer(self, observer: RegistryObserver) -> None:
+        """Unregister a previously-added observer (no-op if absent)."""
+        try:
+            self._observers.remove(observer)
+        except ValueError:
+            pass
+
+    # ── create / read ──────────────────────────────────────────────
+
+    def create(self, spec: RunSpec) -> RunHandle:
+        """Persist a new PENDING run and return its handle.
+
+        The run_id is generated server-side so callers can never
+        accidentally collide. The row is committed before the handle is
+        returned — the MCP tool only hands the id to the user after the
+        create is durable, which is the whole reason this module exists.
+        """
+        run_id = uuid4()
+        now = _now_iso()
+        snapshot_json = json.dumps(spec.spec_snapshot, default=str)
+        with self._write_lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                self._conn.execute(
+                    "INSERT INTO runs "
+                    "(run_id, status, spec_snapshot, metrics, "
+                    " provider_job_id, created_at, updated_at) "
+                    "VALUES (?, ?, ?, '{}', NULL, ?, ?)",
+                    (str(run_id), RunStatus.PENDING.value, snapshot_json, now, now),
+                )
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                raise
+        logger.debug("Created run %s (status=%s)", run_id, RunStatus.PENDING.name)
+        # Read back so the returned handle is exactly what's on disk.
+        handle = self._fetch(run_id)
+        assert handle is not None  # just inserted
+        return handle
+
+    def get(self, run_id: UUID) -> RunHandle | None:
+        """Return the current handle for ``run_id``, or None if absent.
+
+        Reads are uncached: every call hits disk so a second process
+        polling status observes committed transitions immediately.
+        """
+        return self._fetch(run_id)
+
+    def list(self, status: RunStatus | None = None) -> list[RunHandle]:
+        """List runs, newest-first, optionally filtered by status.
+
+        Newest-first matches the CLI ``ondine status`` UX: the run the
+        user just kicked off is the one they want to see at the top.
+        """
+        if status is None:
+            rows = self._conn.execute(
+                # Order by rowid DESC — SQLite assigns rowid in insertion
+                # order, so this gives newest-first deterministically
+                # even when several creates land within the same
+                # microsecond clock tick.
+                "SELECT * FROM runs ORDER BY rowid DESC"
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM runs WHERE status = ? ORDER BY rowid DESC",
+                (status.value,),
+            ).fetchall()
+        return [_row_to_handle(r) for r in rows]
+
+    # ── transition ─────────────────────────────────────────────────
+
+    def transition(
+        self,
+        run_id: UUID,
+        status: RunStatus,
+        *,
+        metrics: dict[str, Any] | None = None,
+        provider_job_id: str | None = None,
+    ) -> RunHandle:
+        """Move ``run_id`` to ``status``, persist, notify observers.
+
+        Validates the transition against ``_ALLOWED_TRANSITIONS``,
+        merges any ``metrics`` / ``provider_job_id`` overrides onto the
+        existing row, commits, then fires observers exactly once with
+        ``(run_id, old_status, new_status)``. Observer exceptions are
+        logged and swallowed so a misbehaving listener cannot corrupt
+        the on-disk state or starve other observers.
+
+        Raises:
+            KeyError: if ``run_id`` does not exist (programmer error —
+                callers only transition known runs).
+            ValueError: if the transition is not in
+                ``_ALLOWED_TRANSITIONS``.
+        """
+        with self._write_lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._conn.execute(
+                    "SELECT * FROM runs WHERE run_id = ?", (str(run_id),)
+                ).fetchone()
+                if row is None:
+                    self._conn.execute("ROLLBACK")
+                    raise KeyError(run_id)
+
+                old_status = RunStatus(row["status"])
+                if status not in _ALLOWED_TRANSITIONS.get(old_status, frozenset()):
+                    self._conn.execute("ROLLBACK")
+                    raise ValueError(
+                        f"Invalid transition {old_status.name} -> {status.name} "
+                        f"for run {run_id}"
+                    )
+
+                merged_metrics = json.loads(row["metrics"] or "{}")
+                if metrics:
+                    merged_metrics.update(metrics)
+
+                updated_at = _now_iso()
+                self._conn.execute(
+                    "UPDATE runs SET status = ?, metrics = ?, "
+                    "  provider_job_id = COALESCE(?, provider_job_id), "
+                    "  updated_at = ? WHERE run_id = ?",
+                    (
+                        status.value,
+                        json.dumps(merged_metrics, default=str),
+                        provider_job_id,
+                        updated_at,
+                        str(run_id),
+                    ),
+                )
+                self._conn.execute("COMMIT")
+            except Exception:
+                # ROLLBACK is idempotent on a non-transaction; guard it.
+                try:
+                    self._conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    pass
+                raise
+
+        new_handle = self._fetch(run_id)
+        assert new_handle is not None  # row exists; just updated
+        self._notify(run_id, old_status, status)
+        logger.info(
+            "Run %s transitioned %s -> %s",
+            run_id,
+            old_status.name,
+            status.name,
+        )
+        return new_handle
+
+    # ── lifecycle ──────────────────────────────────────────────────
+
+    def close(self) -> None:
+        """Close the database connection. Safe to call more than once."""
+        try:
+            self._conn.close()
+        except sqlite3.Error:
+            pass
+
+    # ── internals ──────────────────────────────────────────────────
+
+    def _fetch(self, run_id: UUID) -> RunHandle | None:
+        row = self._conn.execute(
+            "SELECT * FROM runs WHERE run_id = ?", (str(run_id),)
+        ).fetchone()
+        return _row_to_handle(row) if row is not None else None
+
+    def _notify(self, run_id: UUID, old: RunStatus, new: RunStatus) -> None:
+        """Fan out a transition to observers, swallowing their errors."""
+        for observer in list(self._observers):
+            try:
+                observer.on_transition(run_id, old, new)
+            except Exception:
+                logger.exception(
+                    "RegistryObserver %s raised on %s -> %s for run %s",
+                    type(observer).__name__,
+                    old.name,
+                    new.name,
+                    run_id,
+                )
+
+    def __enter__(self) -> RunRegistry:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+def _now_iso() -> str:
+    """UTC ISO-8601 timestamp with microsecond resolution.
+
+    Microsecond precision is required so that rapid sequential creates
+    (the common case — the MCP server may issue several run_ids in one
+    request) get distinct timestamps and ``list()`` can order them
+    newest-first deterministically.
+    """
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")

--- a/ondine/orchestration/run_registry.py
+++ b/ondine/orchestration/run_registry.py
@@ -354,6 +354,52 @@ class RunRegistry:
 
     # ── transition ─────────────────────────────────────────────────
 
+    def update_metrics(
+        self,
+        run_id: UUID,
+        metrics: dict[str, Any],
+    ) -> RunHandle:
+        """Merge ``metrics`` onto the run's row without changing status.
+
+        Distinct from ``transition``: live progress (rows done, cost so far)
+        churns many times per second during a run, while status moves a
+        handful of times across the whole lifetime. Firing observers on every
+        metric write would drown real transition events, and status pollers
+        only re-read the row on demand anyway — so this method persists the
+        merge and returns the updated handle without notifying anyone.
+
+        Raises:
+            KeyError: if ``run_id`` does not exist.
+        """
+        with self._write_lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._conn.execute(
+                    "SELECT metrics FROM runs WHERE run_id = ?", (str(run_id),)
+                ).fetchone()
+                if row is None:
+                    self._conn.execute("ROLLBACK")
+                    raise KeyError(run_id)
+
+                merged = json.loads(row["metrics"] or "{}")
+                merged.update(metrics)
+
+                self._conn.execute(
+                    "UPDATE runs SET metrics = ?, updated_at = ? WHERE run_id = ?",
+                    (json.dumps(merged, default=str), _now_iso(), str(run_id)),
+                )
+                self._conn.execute("COMMIT")
+            except Exception:
+                try:
+                    self._conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    pass
+                raise
+
+        new_handle = self._fetch(run_id)
+        assert new_handle is not None  # row exists; just updated
+        return new_handle
+
     def transition(
         self,
         run_id: UUID,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,9 @@ knowledge = [
     "pymupdf>=1.24",
     "sentence-transformers>=3.0",
 ]
+mcp = [
+    "fastmcp>=3.0.0",
+]
 zep = [
     "zep-cloud>=2.0",
 ]
@@ -121,11 +124,13 @@ all = [
     "azure-identity>=1.15.0",
     "pymupdf>=1.24",
     "sentence-transformers>=3.0",
+    "fastmcp>=3.0.0",
 ]
 
 [project.scripts]
 ondine = "ondine.cli.main:cli"
 hermes = "ondine.cli.main:cli"  # Keep backward compatibility alias
+ondine-mcp = "ondine.mcp.server:main"
 
 [build-system]
 requires = ["maturin>=1.0,<2.0"]

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,404 @@
+"""Tests for the ondine MCP server (§4) — the L5 front door over L4.
+
+The MCP server exposes four tools (ondine_estimate, ondine_run, ondine_status,
+ondine_collect). These tests pin the behavioural contract each tool must hold,
+exercised through :class:`MCPService` (the plain-Python object the FastMCP tool
+functions delegate to). Testing the service directly keeps the unit tests fast
+and deterministic; the FastMCP wiring itself is a thin decorator pass-through
+that adds no logic worth unit-testing.
+
+Contract under test:
+
+* ``ondine_run`` is MANDATORY-budget when reached via MCP — an unset budget
+  must be rejected before any work begins (no runaway spend from a tool call).
+* ``ondine_run`` returns a ``run_id`` immediately and does not block on the LLM;
+  the work runs on a background thread that writes progress to the registry.
+* ``ondine_run`` injects the budget into the processing spec so the engine's
+  own BudgetController enforces the cap end-to-end.
+* ``ondine_status`` reads live progress (rows done, cost so far, %) from the
+  registry, even mid-flight.
+* ``ondine_status`` reports "not found" distinctly from a real run.
+* ``ondine_collect`` returns the result summary + output path once the run
+  reaches a terminal state, and refuses while the run is still in flight.
+* ``ondine_estimate`` is side-effect-free: it never creates a registry row and
+  never writes a checkpoint.
+* The registry progress observer writes rows/cost to the registry as the
+  pipeline runs, so ``ondine_status`` sees non-zero progress mid-run.
+
+The LLM client is mocked at the architectural boundary (``create_llm_client``)
+so no network call is made; everything else is real.
+"""
+
+from __future__ import annotations
+
+import time
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+import pandas as pd
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from ondine.core.models import LLMResponse
+from ondine.mcp.server import MCPService, create_server
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+_CONFIG_YAML = """
+dataset:
+  source_type: csv
+  source_path: "{input}"
+  input_columns: [text]
+  output_columns: [result]
+prompt:
+  template: "Classify: {{text}}"
+llm:
+  provider: openai
+  model: gpt-4o-mini
+processing:
+  batch_size: 5
+  concurrency: 2
+"""
+
+
+def _write_dataset(path: Path, rows: int = 12) -> None:
+    df = pd.DataFrame({"text": [f"row {i}" for i in range(rows)]})
+    df.to_csv(path, index=False)
+
+
+def _make_fake_llm_client_cls():
+    """Build a deterministic LLMClient subclass that needs no network.
+
+    Mirrors the proven mock pattern in test_run_registry.py: subclass the real
+    ``LLMClient`` so pricing/estimate_tokens/calculate_cost come for free, and
+    override only the invoke path to return a canned response.
+    """
+    from ondine.adapters.llm_client import LLMClient
+
+    class _FakeLLMClient(LLMClient):
+        def invoke(self, prompt, **kwargs):
+            return LLMResponse(
+                text="positive",
+                tokens_in=5,
+                tokens_out=1,
+                model=self.model,
+                cost=Decimal("0.001"),
+                latency_ms=1.0,
+            )
+
+        async def ainvoke(self, prompt, **kwargs):
+            return self.invoke(prompt, **kwargs)
+
+        def structured_invoke(self, prompt, output_cls, **kwargs):
+            return self.invoke(prompt, **kwargs)
+
+        async def structured_invoke_async(self, prompt, output_cls, **kwargs):
+            return self.invoke(prompt, **kwargs)
+
+        async def start(self):
+            pass
+
+        async def stop(self):
+            pass
+
+        def estimate_tokens(self, text):
+            return len(text) // 4
+
+    return _FakeLLMClient
+
+
+@pytest.fixture
+def fake_llm(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Patch the LLM client factory so no provider is contacted.
+
+    The pipeline resolves ``create_llm_client`` at call time from
+    ``ondine.api.pipeline``; patching it there covers both the sync and async
+    execution paths. Returns the fake client instance the pipeline will use.
+    """
+    fake_cls = _make_fake_llm_client_cls()
+
+    def _factory(llm_spec, *args, **kwargs):
+        return fake_cls(llm_spec)
+
+    monkeypatch.setattr("ondine.api.pipeline.create_llm_client", _factory)
+    return _factory
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> MCPService:
+    return MCPService(registry_dir=tmp_path)
+
+
+def _config_yaml(input_path: Path) -> str:
+    return _CONFIG_YAML.format(input=str(input_path))
+
+
+# ── regression: budget is mandatory on ondine_run ────────────────────
+
+
+def test_run_rejects_missing_budget(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: the architecture proposal mandates a budget cap on every MCP
+    run. If ondine_run accepted a missing budget, a tool caller could launch an
+    unbounded spend job with no ceiling — the exact footgun the cap exists to
+    prevent. The rejection must happen before any run is created.
+    """
+    inp = tmp_path / "in.csv"
+    _write_dataset(inp)
+    out = tmp_path / "out.csv"
+
+    with pytest.raises(ValueError, match="(?i)budget"):
+        service.ondine_run(
+            config_yaml=_config_yaml(inp),
+            input_path=str(inp),
+            output_path=str(out),
+            budget=None,
+        )
+
+    # No run row should have been persisted — rejection is pre-flight.
+    assert service.list_runs() == []
+
+
+def test_run_rejects_zero_budget(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: a budget of 0 or negative is equivalent to no cap (the
+    engine treats ``None`` as unlimited and ``0`` would trip instantly or never
+    depending on path). MCP must reject non-positive budgets explicitly.
+    """
+    inp = tmp_path / "in.csv"
+    _write_dataset(inp)
+    out = tmp_path / "out.csv"
+
+    with pytest.raises(ValueError, match="(?i)budget"):
+        service.ondine_run(
+            config_yaml=_config_yaml(inp),
+            input_path=str(inp),
+            output_path=str(out),
+            budget=0,
+        )
+
+
+# ── regression: ondine_run returns a run_id and does not block ───────
+
+
+def test_run_returns_run_id_immediately_and_does_not_block(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: ondine_run is documented to 'return run_id immediately
+    (never block)'. If it blocked on execute(), the MCP client would time out
+    waiting for a long job and the user would lose the handle to poll. The call
+    must return a resolvable run_id while the LLM has barely started.
+    """
+    inp = tmp_path / "in.csv"
+    _write_dataset(inp, rows=50)
+    out = tmp_path / "out.csv"
+
+    handle = service.ondine_run(
+        config_yaml=_config_yaml(inp),
+        input_path=str(inp),
+        output_path=str(out),
+        budget=Decimal("5.00"),
+    )
+
+    # A run_id is returned and is durable in the registry.
+    assert handle["run_id"]
+    status = service.ondine_status(handle["run_id"])
+    assert status["run_id"] == handle["run_id"]
+
+    # The returned status is a real, trackable state — not "unknown".
+    assert status["status"] in ("pending", "running", "succeeded", "failed", "partial")
+
+
+# ── regression: budget is injected into the processing spec ──────────
+
+
+def test_run_injects_budget_into_spec(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: the budget cap must reach the engine's own BudgetController,
+    not just be stored in the registry. If ondine_run only recorded the budget
+    for bookkeeping, a runaway job would blow past it because the invocation
+    stage never sees the limit. The persisted spec snapshot must carry it.
+    """
+    inp = tmp_path / "in.csv"
+    _write_dataset(inp)
+    out = tmp_path / "out.csv"
+
+    handle = service.ondine_run(
+        config_yaml=_config_yaml(inp),
+        input_path=str(inp),
+        output_path=str(out),
+        budget=Decimal("2.50"),
+    )
+
+    spec_snapshot = service.get_spec_snapshot(handle["run_id"])
+    assert spec_snapshot is not None
+    assert str(spec_snapshot["processing"]["max_budget"]).startswith("2.5")
+
+
+# ── regression: ondine_status reports live progress mid-flight ───────
+
+
+def test_status_reports_live_progress_during_run(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: ondine_status must show rows-done / cost-so-far while the
+    job is RUNNING. If progress never reached the registry, a user polling
+    status would see 0/0 until the very end — indistinguishable from a hung
+    job. The RegistryProgressObserver must forward progress to the registry.
+    """
+    inp = tmp_path / "in.csv"
+    _write_dataset(inp, rows=20)
+    out = tmp_path / "out.csv"
+
+    handle = service.ondine_run(
+        config_yaml=_config_yaml(inp),
+        input_path=str(inp),
+        output_path=str(out),
+        budget=Decimal("5.00"),
+    )
+
+    # Wait for the background run to make progress or finish.
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        st = service.ondine_status(handle["run_id"])
+        if st["status"] in ("succeeded", "failed", "partial"):
+            break
+        # While running, either rows_done>0 (progress observed) or we polled
+        # before the first batch landed — keep waiting.
+        time.sleep(0.05)
+
+    final = service.ondine_status(handle["run_id"])
+    assert final["status"] == "succeeded"
+    assert final["rows_done"] == 20
+    assert Decimal(final["cost"]) > 0
+
+
+# ── regression: ondine_status distinguishes unknown run_id ───────────
+
+
+def test_status_unknown_run_id_raises(
+    service: MCPService,
+) -> None:
+    """Regression: polling a run_id that was never created must surface a clear
+    'not found' error, not silently return a zeroed-out status. Otherwise a
+    typo in the run_id would look like an empty, instantly-finished job.
+    """
+    with pytest.raises(KeyError):
+        service.ondine_status(str(uuid4()))
+
+
+# ── regression: ondine_collect returns summary for a finished run ────
+
+
+def test_collect_returns_summary_after_success(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: ondine_collect is the terminal readout — rows, cost, and the
+    output path. If it didn't surface the output path, the user would have no
+    way to find their result file from the tool alone.
+    """
+    inp = tmp_path / "in.csv"
+    _write_dataset(inp, rows=8)
+    out = tmp_path / "out.csv"
+
+    handle = service.ondine_run(
+        config_yaml=_config_yaml(inp),
+        input_path=str(inp),
+        output_path=str(out),
+        budget=Decimal("5.00"),
+    )
+
+    collected = service.wait_and_collect(handle["run_id"], timeout=30)
+    assert collected["status"] == "succeeded"
+    assert collected["rows_done"] == 8
+    assert collected["output_path"] == str(out)
+    assert Decimal(collected["cost"]) > 0
+    # The output file really exists — collect doesn't lie about the artefact.
+    assert out.exists()
+
+
+def test_collect_refuses_in_flight_run(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: ondine_collect on a still-running job must not return a
+    half-written summary. It should report that the run is not finished so the
+    caller knows to poll status and come back.
+    """
+    # We can't easily freeze the run mid-flight with the fake client (it's
+    # fast), so instead seed a PENDING run directly and assert collect refuses.
+    handle = service._seed_pending_run()  # noqa: SLF001 — test-only seam
+    with pytest.raises(ValueError, match="(?i)not.*finished|in.?flight|running"):
+        service.ondine_collect(str(handle.run_id))
+
+
+# ── regression: ondine_estimate is side-effect-free ──────────────────
+
+
+def test_estimate_is_side_effect_free(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: ondine_estimate is the 'demo tool' — fast and side-effect
+    -free. If it persisted a registry row or wrote a checkpoint, every estimate
+    call would pollute the run history and the checkpoint dir. Estimate must
+    leave the registry empty.
+    """
+    inp = tmp_path / "in.csv"
+    _write_dataset(inp)
+
+    estimate = service.ondine_estimate(config_yaml=_config_yaml(inp))
+
+    assert estimate["rows"] == 12
+    assert Decimal(estimate["total_cost"]) >= 0
+    assert estimate["total_tokens"] >= 0
+    # No run row created.
+    assert service.list_runs() == []
+
+
+# ── regression: create_server builds a FastMCP app with 4 tools ──────
+
+
+def test_create_server_registers_four_tools() -> None:
+    """Regression: the public entrypoint must wire exactly the four documented
+    tools onto a FastMCP server so an MCP client discovers them by name. If a
+    tool were missing or misnamed, the client would see an incomplete surface.
+    """
+    import asyncio
+
+    from fastmcp import FastMCP
+
+    server = create_server()
+    assert isinstance(server, FastMCP)
+    tools = asyncio.run(server.list_tools())
+    names = sorted(t.name for t in tools)
+    assert names == ["ondine_collect", "ondine_estimate", "ondine_run", "ondine_status"]
+
+
+def test_create_server_tools_are_callable(service: MCPService) -> None:
+    """The four service methods exist and are bound — guards against a rename
+    silently breaking the MCP surface.
+    """
+    for name in ("ondine_estimate", "ondine_run", "ondine_status", "ondine_collect"):
+        assert hasattr(service, name), f"MCPService missing tool {name!r}"

--- a/tests/unit/test_run_registry.py
+++ b/tests/unit/test_run_registry.py
@@ -494,6 +494,52 @@ def test_pipeline_execute_failure_records_failed_state(
     assert final.status is RunStatus.FAILED
 
 
+# ── regression: update_metrics writes live progress without a transition ──
+
+
+def test_update_metrics_merges_without_changing_status(
+    registry: RunRegistry,
+) -> None:
+    """Regression: the MCP ``ondine_status`` tool reports live rows/cost for a
+    RUNNING job. If update_metrics transitioned status or replaced metrics
+    wholesale, status polling would either break the FSM or lose the fields the
+    terminal transition wrote. Live progress must merge onto the row in place.
+    """
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+    registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    registry.update_metrics(handle.run_id, {"processed_rows": 42, "cost": "1.25"})
+
+    after = registry.get(handle.run_id)
+    assert after is not None
+    assert after.status is RunStatus.RUNNING  # unchanged
+    assert after.metrics["processed_rows"] == 42
+    assert after.metrics["cost"] == "1.25"
+
+
+def test_update_metrics_is_visible_to_a_second_process(
+    tmp_path: Path,
+) -> None:
+    """Regression: a status poller is a different process opening its own
+    registry handle. If update_metrics were in-memory only, the MCP status tool
+    would never see live progress from the worker thread/process that ran the
+    job. The merge must hit the on-disk row.
+    """
+    registry_a = RunRegistry(tmp_path / "runs.db")
+    handle = registry_a.create(RunSpec(pipeline_id=str(uuid4())))
+    registry_a.transition(handle.run_id, RunStatus.RUNNING)
+    registry_a.update_metrics(handle.run_id, {"processed_rows": 7})
+    registry_a.close()
+
+    registry_b = RunRegistry(tmp_path / "runs.db")
+    try:
+        seen = registry_b.get(handle.run_id)
+        assert seen is not None
+        assert seen.metrics.get("processed_rows") == 7
+    finally:
+        registry_b.close()
+
+
 # ── fixtures ──────────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_run_registry.py
+++ b/tests/unit/test_run_registry.py
@@ -1,0 +1,505 @@
+"""Tests for RunRegistry — persistent job index for pipeline runs.
+
+Every test pins a concrete regression. The contract under test:
+
+* `create(spec)` returns a RunHandle with status PENDING, durable on disk.
+* `get(run_id)` returns the up-to-date handle. `list(status?)` filters.
+* `transition(run_id, status, **fields)` validates the transition, persists,
+  and notifies RegistryObservers exactly once with (run_id, old, new).
+* Pipelines that pass `run_id=` to `execute()` register and progress through
+  PENDING → RUNNING → SUCCEEDED|FAILED|PARTIAL. Default `run_id=None` leaves
+  behaviour unchanged (no registry artifact on disk).
+
+The SUT is `RunRegistry` against a real on-disk SQLite DB in a temp dir —
+the entire motivation is crash-safe durability, which mocks cannot prove.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+from uuid import UUID, uuid4
+
+import pandas as pd
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from ondine.core.specifications import (
+    DatasetSpec,
+    DataSourceType,
+    LLMProvider,
+    LLMSpec,
+    PipelineSpecifications,
+    PromptSpec,
+)
+from ondine.orchestration.run_registry import (
+    RegistryObserver,
+    RunRegistry,
+    RunSpec,
+    RunStatus,
+)
+
+# ── regression #1: create persists a PENDING run ──────────────────────
+
+
+def test_create_returns_pending_handle(registry: RunRegistry) -> None:
+    """Regression: if create did not persist, the MCP ``ondine_run`` tool
+    would return a run_id that no later ``ondine_status`` could resolve —
+    a lost job invisible to the user."""
+    spec = RunSpec(pipeline_id=str(uuid4()), dataset="df")
+    handle = registry.create(spec)
+
+    assert isinstance(handle.run_id, UUID)
+    assert handle.status is RunStatus.PENDING
+    assert handle.spec_snapshot == {"pipeline_id": spec.pipeline_id, "dataset": "df"}
+
+
+def test_get_returns_up_to_date_handle(registry: RunRegistry) -> None:
+    """Regression: get() must read the current on-disk state, not a
+    cached handle. Otherwise a second process polling status for a
+    long-running job would forever see PENDING."""
+    spec = RunSpec(pipeline_id=str(uuid4()))
+    handle = registry.create(spec)
+
+    registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    fresh = registry.get(handle.run_id)
+    assert fresh.status is RunStatus.RUNNING
+    assert fresh.run_id == handle.run_id
+
+
+def test_get_unknown_run_id_returns_none(registry: RunRegistry) -> None:
+    """Regression: callers (CLI, MCP) must distinguish "no such run"
+    from "run exists". A KeyError forces callers into try/except noise;
+    None is the clean sentinel."""
+    assert registry.get(uuid4()) is None
+
+
+# ── regression #2: durability across processes ────────────────────────
+
+
+def test_create_survives_process_kill(tmp_path: Path) -> None:
+    """Regression: the MCP server issues a run_id immediately, then a
+    worker process picks it up. If the registry were not crash-durable
+    across process boundaries, the worker could never resolve the run
+    the server started. Mirror the ResponseCache crash test: hard
+    ``os._exit`` proves the WAL commit survived."""
+    db_path = tmp_path / "runs.db"
+    spec = RunSpec(pipeline_id=str(uuid4()), dataset="df")
+    spec_dict = spec.to_dict()
+
+    worker = f"""
+import os, sys
+from ondine.orchestration.run_registry import RunRegistry, RunSpec
+registry = RunRegistry({str(db_path)!r})
+registry.create(RunSpec.from_dict({spec_dict!r}))
+os._exit(9)
+"""
+
+    proc = subprocess.run(
+        [sys.executable, "-c", worker],
+        env={**os.environ, "PYTHONPATH": os.getcwd()},
+        capture_output=True,
+        timeout=30,
+    )
+    assert proc.returncode == 9, (
+        f"worker did not hard-exit: {proc.returncode}\\n{proc.stderr.decode()}"
+    )
+
+    registry = RunRegistry(db_path)
+    runs = registry.list()
+    assert len(runs) == 1
+    assert runs[0].status is RunStatus.PENDING
+
+
+def test_reopen_sees_previously_written_runs(tmp_path: Path) -> None:
+    """Regression: status lookups happen in a new process (the CLI's
+    ``ondine status <run_id>`` is a fresh invocation). Data must survive
+    the close/reopen boundary."""
+    db_path = tmp_path / "reopen.db"
+    a = RunRegistry(db_path)
+    spec = RunSpec(pipeline_id=str(uuid4()))
+    handle = a.create(spec)
+    a.close()
+
+    b = RunRegistry(db_path)
+    try:
+        fresh = b.get(handle.run_id)
+        assert fresh is not None
+        assert fresh.status is RunStatus.PENDING
+    finally:
+        b.close()
+
+
+# ── regression #3: transition validation & observer fan-out ─────────
+
+
+def test_valid_transition_persists_and_returns_updated_handle(
+    registry: RunRegistry,
+) -> None:
+    """Regression: transition() must both persist and return the new
+    state. If it returned the stale handle, callers chaining off the
+    return would race the on-disk write."""
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+
+    updated = registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    assert updated.status is RunStatus.RUNNING
+    assert registry.get(handle.run_id).status is RunStatus.RUNNING
+
+
+def test_invalid_transition_raises_value_error(registry: RunRegistry) -> None:
+    """Regression: PENDING → SUCCEEDED must be rejected — a run that
+    never registered as RUNNING cannot be SUCCEEDED. Without this guard
+    the registry would record impossible state histories that a later
+    consumer (MCP /admin) would treat as valid."""
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+
+    with pytest.raises(ValueError, match="transition"):
+        registry.transition(handle.run_id, RunStatus.SUCCEEDED)
+
+
+def test_transition_unknown_run_id_raises_key_error(registry: RunRegistry) -> None:
+    """Regression: transitioning a non-existent run is a programmer error
+    (the MCP tool only operates on known run_ids). A silent no-op would
+    let a bug in the caller pass undetected."""
+    with pytest.raises(KeyError):
+        registry.transition(uuid4(), RunStatus.RUNNING)
+
+
+def test_transition_invokes_observers_exactly_once(
+    registry: RunRegistry,
+) -> None:
+    """Regression: observers drive the live progress feed in the MCP
+    server. Firing twice duplicates every status event in the user's
+    stream; firing zero times hides completion. Exactly once."""
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+    seen: list[tuple[UUID, RunStatus, RunStatus]] = []
+
+    class Recorder(RegistryObserver):
+        def on_transition(self, run_id: UUID, old: RunStatus, new: RunStatus) -> None:
+            seen.append((run_id, old, new))
+
+    registry.add_observer(Recorder())
+
+    registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    assert seen == [(handle.run_id, RunStatus.PENDING, RunStatus.RUNNING)]
+
+
+def test_observer_exception_does_not_break_transition(
+    registry: RunRegistry,
+) -> None:
+    """Regression: an observer (e.g. a metrics sink) must not be able to
+    take down the registry — the transition must still persist even when
+    a downstream listener raises. Matches the silent-observer-failure
+    contract of ``ExecutionContext.notify_progress``."""
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+
+    class Boom(RegistryObserver):
+        def on_transition(self, run_id: UUID, old: RunStatus, new: RunStatus) -> None:
+            raise RuntimeError("observer exploded")
+
+    registry.add_observer(Boom())
+
+    registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    assert registry.get(handle.run_id).status is RunStatus.RUNNING
+
+
+# ── regression #4: metrics & provider_job_id fields ───────────────────
+
+
+def test_transition_updates_metrics_and_provider_job_id(
+    registry: RunRegistry,
+) -> None:
+    """Regression: the ProviderBatchBackend (§5) needs to persist the
+    provider's batch_id once a job is submitted (SUBMITTED_REMOTE).
+    Metrics (rows processed, cost so far) are updated on every
+    transition by the live executor. If transition dropped these,
+    the MCP ``ondine_status`` tool would show stale zeroes."""
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+    registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    updated = registry.transition(
+        handle.run_id,
+        RunStatus.SUBMITTED_REMOTE,
+        metrics={"rows": 1000, "cost": str(Decimal("0.42"))},
+        provider_job_id="batch_abc123",
+    )
+
+    assert updated.provider_job_id == "batch_abc123"
+    assert updated.metrics["rows"] == 1000
+    fresh = registry.get(handle.run_id)
+    assert fresh.provider_job_id == "batch_abc123"
+    assert fresh.metrics["cost"] == str(Decimal("0.42"))
+
+
+# ── regression #5: list filters & ordering ────────────────────────────
+
+
+def test_list_filters_by_status(registry: RunRegistry) -> None:
+    """Regression: the MCP ``ondine_status`` tool lists RUNNING jobs for
+    the dashboard. If list(status=) ignored the filter, the dashboard
+    would show terminal jobs forever and the user would never know a
+    run finished until they refreshed."""
+    h1 = registry.create(RunSpec(pipeline_id=str(uuid4())))
+    h2 = registry.create(RunSpec(pipeline_id=str(uuid4())))
+    h3 = registry.create(RunSpec(pipeline_id=str(uuid4())))
+
+    registry.transition(h2.run_id, RunStatus.RUNNING)
+    registry.transition(h3.run_id, RunStatus.RUNNING)
+    registry.transition(h3.run_id, RunStatus.SUCCEEDED)
+
+    assert {h.run_id for h in registry.list()} == {h1.run_id, h2.run_id, h3.run_id}
+    assert [h.run_id for h in registry.list(RunStatus.RUNNING)] == [h2.run_id]
+    assert [h.run_id for h in registry.list(RunStatus.PENDING)] == [h1.run_id]
+    assert registry.list(RunStatus.FAILED) == []
+
+
+def test_list_returns_newest_first(registry: RunRegistry) -> None:
+    """Regression: the CLI ``ondine status`` shows the most recent run
+    first. If list returned oldest-first, the user would scroll past
+    stale jobs to find their latest one."""
+    ids = [registry.create(RunSpec(pipeline_id=str(uuid4()))).run_id for _ in range(3)]
+    listed = [h.run_id for h in registry.list()]
+    assert listed == list(reversed(ids))
+
+
+# ── regression #6: spec_snapshot round-trip ───────────────────────────
+
+
+def test_spec_snapshot_roundtrips_arbitrary_dict(registry: RunRegistry) -> None:
+    """Regression: the spec snapshot is what resume relies on — without
+    it, a crashed ``provider_batch`` run could not be reattached by the
+    CLI. Losing nested keys would silently drop the prompt/model."""
+    snapshot = {
+        "pipeline_id": str(uuid4()),
+        "model": "gpt-4o-mini",
+        "prompt": "Summarize: {text}",
+        "nested": {"batch_size": 32, "columns": ["a", "b"]},
+    }
+    handle = registry.create(RunSpec.from_dict({"spec_snapshot": snapshot}))
+
+    fresh = registry.get(handle.run_id)
+    assert fresh.spec_snapshot == snapshot
+    assert fresh.spec_snapshot["nested"]["columns"] == ["a", "b"]
+
+
+# ── regression #7: Pipeline.execute(run_id=...) integration ──────────
+
+
+def _make_pipeline(
+    checkpoint_dir: Path,
+    *,
+    failing: bool = False,
+) -> tuple[Any, PipelineSpecifications, Any]:
+    """Build a minimal Pipeline with a mocked LLM client.
+
+    The mock returns deterministic responses so execute() succeeds
+    without network access — we only need the registry wire-up, not the
+    LLM behaviour (which has its own test suite).
+
+    When ``failing=True`` the mock client raises on every invoke and the
+    processing spec uses ``ErrorPolicy.FAIL`` so the error propagates
+    out of execute(). This exercises the real failure path instead of
+    inventing a ``fail_fast`` knob that would just shadow ErrorPolicy.
+    """
+    from unittest.mock import patch
+
+    from ondine.adapters.llm_client import LLMClient
+    from ondine.api.pipeline import Pipeline
+    from ondine.core.models import LLMResponse
+    from ondine.core.specifications import ErrorPolicy, ProcessingSpec
+
+    df = pd.DataFrame({"text": ["a", "b", "c"]})
+    processing = ProcessingSpec(
+        checkpoint_dir=checkpoint_dir,
+        cleanup_on_success=False,
+        progress_mode="none",
+        max_retries=0,
+        retry_delay=0.0,
+    )
+    if failing:
+        processing = processing.model_copy(update={"error_policy": ErrorPolicy.FAIL})
+
+    specs = PipelineSpecifications(
+        dataset=DatasetSpec(
+            source_type=DataSourceType.DATAFRAME,
+            input_columns=["text"],
+            output_columns=["result"],
+        ),
+        prompt=PromptSpec(template="{text}"),
+        llm=LLMSpec(
+            provider=LLMProvider.OPENAI,
+            model="gpt-4o-mini",
+            input_cost_per_1k_tokens=Decimal("0.00015"),
+            output_cost_per_1k_tokens=Decimal("0.0006"),
+        ),
+        processing=processing,
+    )
+
+    if failing:
+
+        class FailingClient(LLMClient):
+            def invoke(self, prompt, **kwargs):
+                raise RuntimeError("simulated provider failure")
+
+            async def ainvoke(self, prompt, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            def structured_invoke(self, prompt, output_cls, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            async def structured_invoke_async(self, prompt, output_cls, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            async def start(self):
+                pass
+
+            async def stop(self):
+                pass
+
+            def estimate_tokens(self, text):
+                return len(text) // 4
+
+        mock_client = FailingClient(specs.llm)
+    else:
+
+        class MockClient(LLMClient):
+            def invoke(self, prompt, **kwargs):
+                return LLMResponse(
+                    text="ok",
+                    tokens_in=1,
+                    tokens_out=1,
+                    model=self.model,
+                    cost=Decimal("0.0001"),
+                    latency_ms=1.0,
+                )
+
+            async def ainvoke(self, prompt, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            def structured_invoke(self, prompt, output_cls, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            async def structured_invoke_async(self, prompt, output_cls, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            async def start(self):
+                pass
+
+            async def stop(self):
+                pass
+
+            def estimate_tokens(self, text):
+                return len(text) // 4
+
+        mock_client = MockClient(specs.llm)
+
+    pipeline = Pipeline(specs, dataframe=df)
+    patcher = patch(
+        "ondine.api.pipeline.create_llm_client",
+        return_value=mock_client,
+    )
+    patcher.start()
+    return pipeline, specs, patcher
+
+
+def test_pipeline_execute_with_run_id_registers_and_traces(
+    tmp_path: Path,
+) -> None:
+    """Regression: ``Pipeline.execute(run_id=...)`` must register the run
+    and trace its terminal state in the registry. Without the wire-up,
+    the MCP ``ondine_status`` tool would return PENDING forever for a
+    run that actually finished — a broken dashboard."""
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+    registry = RunRegistry(checkpoint_dir)
+    spec = RunSpec(
+        pipeline_id=str(uuid4()),
+        dataset="df",
+        spec_snapshot={"model": "gpt-4o-mini"},
+    )
+    handle = registry.create(spec)
+
+    pipeline, _, patcher = _make_pipeline(checkpoint_dir)
+    try:
+        pipeline.execute(run_id=handle.run_id, registry=registry)
+    finally:
+        patcher.stop()
+
+    final = registry.get(handle.run_id)
+    assert final is not None
+    assert final.status is RunStatus.SUCCEEDED
+    assert final.metrics["total_rows"] == 3
+
+
+def test_pipeline_execute_without_run_id_leaves_registry_empty(
+    tmp_path: Path,
+) -> None:
+    """Regression: the default path (run_id=None) must NOT touch the
+    registry. Existing users who never opted in would otherwise find a
+    ``runs.db`` file appearing in their checkpoint dir — a breaking
+    side-effect on every execute() call."""
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+    registry = RunRegistry(checkpoint_dir)
+
+    pipeline, _, patcher = _make_pipeline(checkpoint_dir)
+    try:
+        pipeline.execute()
+    finally:
+        patcher.stop()
+
+    registry2 = RunRegistry(checkpoint_dir)
+    try:
+        assert registry2.list() == []
+    finally:
+        registry.close()
+        registry2.close()
+
+
+def test_pipeline_execute_failure_records_failed_state(
+    tmp_path: Path,
+) -> None:
+    """Regression: when the pipeline raises, the registry must record
+    FAILED so the dashboard doesn't keep a dead run as RUNNING —
+    otherwise operators never know it died.
+
+    We exercise the real failure path: a mock LLM client that raises and
+    an ``ErrorPolicy.FAIL`` processing spec, so the error propagates out
+    of execute() exactly as a genuine provider outage would.
+    """
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+    registry = RunRegistry(checkpoint_dir)
+    spec = RunSpec(pipeline_id=str(uuid4()), dataset="df")
+    handle = registry.create(spec)
+
+    pipeline, _, patcher = _make_pipeline(checkpoint_dir, failing=True)
+    try:
+        with pytest.raises(Exception):
+            pipeline.execute(run_id=handle.run_id, registry=registry)
+    finally:
+        patcher.stop()
+
+    final = registry.get(handle.run_id)
+    assert final is not None
+    assert final.status is RunStatus.FAILED
+
+
+# ── fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> RunRegistry:
+    db_path = tmp_path / "runs.db"
+    r = RunRegistry(db_path)
+    yield r
+    r.close()


### PR DESCRIPTION
4-tool MCP server: ondine_estimate, ondine_run, ondine_status, ondine_collect.
Uses RunRegistry for durable cross-process state. Budget cap mandatory on MCP runs.
Tests: 30/30 pass (17 registry + 13 MCP). Merge order: 3rd (depends on t2).