### PR TITLE
feat(orchestration): ProviderBatchBackend + LiveBackend on unified protocol

### DIFF
--- a/ondine/api/pipeline.py
+++ b/ondine/api/pipeline.py
@@ -39,6 +39,8 @@ from ondine.orchestration import (
     ExecutionStrategy,
     LoggingObserver,
     ProgressBarObserver,
+    RunRegistry,
+    RunStatus,
     StateManager,
     StreamingExecutor,
     SyncExecutor,
@@ -239,7 +241,13 @@ class Pipeline:
             confidence="sample-based",
         )
 
-    def execute(self, resume_from: UUID | None = None) -> ExecutionResult:
+    def execute(
+        self,
+        resume_from: UUID | None = None,
+        *,
+        run_id: UUID | None = None,
+        registry: "RunRegistry | None" = None,
+    ) -> ExecutionResult:
         """
         Execute pipeline end-to-end.
 
@@ -248,6 +256,12 @@ class Pipeline:
 
         Args:
             resume_from: Optional session ID to resume from checkpoint (for fault tolerance)
+            run_id: Optional run registry ID. When provided alongside ``registry``,
+                the run is traced through PENDING -> RUNNING -> SUCCEEDED|FAILED in
+                the registry so external observers (CLI, MCP) can follow progress.
+                Default ``None`` leaves behaviour unchanged — no registry artifact.
+            registry: Optional :class:`~ondine.orchestration.RunRegistry`. Required
+                when ``run_id`` is set; ignored otherwise.
 
         Returns:
             ExecutionResult containing:
@@ -378,6 +392,18 @@ class Pipeline:
         for observer in self.observers:
             observer.on_pipeline_start(self, context)
 
+        # Trace the run in the registry if the caller opted in. We move
+        # PENDING -> RUNNING now so a crash after this line still leaves
+        # a durable RUNNING record for the CLI/MCP to report. The
+        # terminal transition (SUCCEEDED/FAILED) is recorded below.
+        if run_id is not None and registry is not None:
+            try:
+                registry.transition(run_id, RunStatus.RUNNING)
+            except Exception as reg_err:  # noqa: BLE001
+                self.logger.warning(
+                    f"RunRegistry transition to RUNNING failed for {run_id}: {reg_err}"
+                )
+
         try:
             # Execute stages (preprocessing happens inside if enabled)
             result_df = self._execute_stages(context, state_manager)
@@ -473,6 +499,27 @@ class Pipeline:
             if tracker_ref is not None:
                 tracker_ref.show_summary(result)
 
+            # Record terminal success in the registry. We snapshot the
+            # row count and cost so the MCP ``ondine_status`` tool can
+            # report final figures without re-reading the result object.
+            if run_id is not None and registry is not None:
+                try:
+                    registry.transition(
+                        run_id,
+                        RunStatus.SUCCEEDED,
+                        metrics={
+                            "total_rows": int(context.total_rows),
+                            "processed_rows": int(result.metrics.processed_rows),
+                            "failed_rows": int(result.metrics.failed_rows),
+                            "cost": str(result.costs.total_cost),
+                        },
+                    )
+                except Exception as reg_err:  # noqa: BLE001
+                    self.logger.warning(
+                        f"RunRegistry transition to SUCCEEDED failed "
+                        f"for {run_id}: {reg_err}"
+                    )
+
             return result
 
         except KeyboardInterrupt:
@@ -491,6 +538,25 @@ class Pipeline:
                 f"Pipeline failed. Checkpoint saved. "
                 f"Resume with: pipeline.execute(resume_from=UUID('{context.session_id}'))"
             )
+
+            # Record terminal failure in the registry before re-raising.
+            # An operator polling ``ondine status`` must see FAILED, not a
+            # stale RUNNING — otherwise dead runs haunt the dashboard.
+            if run_id is not None and registry is not None:
+                try:
+                    registry.transition(
+                        run_id,
+                        RunStatus.FAILED,
+                        metrics={
+                            "total_rows": int(context.total_rows),
+                            "error": f"{type(e).__name__}: {e}",
+                        },
+                    )
+                except Exception as reg_err:  # noqa: BLE001
+                    self.logger.warning(
+                        f"RunRegistry transition to FAILED failed "
+                        f"for {run_id}: {reg_err}"
+                    )
 
             # Notify legacy observers of error
             for observer in self.observers:

--- a/ondine/api/pipeline.py
+++ b/ondine/api/pipeline.py
@@ -9,7 +9,7 @@ from collections.abc import AsyncIterator, Iterator
 from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 import pandas as pd
@@ -39,7 +39,9 @@ from ondine.orchestration import (
     ExecutionStrategy,
     LoggingObserver,
     ProgressBarObserver,
+    RunHandle,
     RunRegistry,
+    RunSpec,
     RunStatus,
     StateManager,
     StreamingExecutor,
@@ -47,6 +49,9 @@ from ondine.orchestration import (
     create_progress_tracker,
 )
 from ondine.orchestration.progress_tracker import NoOpProgressTracker
+
+if TYPE_CHECKING:
+    from ondine.orchestration.backends.provider_batch import ProviderBatchBackend
 from ondine.stages import (
     BatchAggregatorStage,
     BatchDisaggregatorStage,
@@ -1740,6 +1745,159 @@ class Pipeline:
             # (Don't stop early - use all attempts to get closest to 100%)
 
         return result
+
+    # ── Provider-batch mode (§5): submit + attach ─────────────────
+    #
+    # These two methods split the pipeline into the same shared front
+    # half (Load → Format → Aggregate) and back half (Disaggregate →
+    # Parse → Write) that ``execute()`` runs in one shot, with the
+    # ProviderBatchBackend as the middle. ``submit()`` runs the front
+    # half + ``backend.submit()`` and returns a RunHandle whose
+    # ``provider_job_id`` is durable in the RunRegistry; ``attach()``
+    # resumes from that handle, polls/collects the results, and runs the
+    # back half. The split is what makes batch mode non-blocking.
+
+    def submit(
+        self,
+        *,
+        registry: RunRegistry | None = None,
+    ) -> RunHandle:
+        """Run the front half + submit a provider batch job (non-blocking).
+
+        Loads and formats the data, compiles prompts to a provider
+        JSONL, uploads it, and kicks off the batch job. Returns a
+        :class:`RunHandle` — durable in the ``registry`` — carrying the
+        ``provider_job_id`` so :meth:`attach` (in this or another
+        process) can later poll and collect the results.
+
+        Only valid when ``processing.execution_mode == 'provider_batch'``;
+        live-mode pipelines must use :meth:`execute`.
+
+        Args:
+            registry: Where to persist the run. If omitted, a registry
+                is created in the default checkpoint directory.
+
+        Returns:
+            RunHandle with ``status == SUBMITTED_REMOTE`` and the
+            ``provider_job_id`` populated.
+        """
+        if self.specifications.processing.execution_mode != "provider_batch":
+            raise ValueError(
+                "submit() requires execution_mode='provider_batch'. "
+                "Use execute() for live mode."
+            )
+
+        registry = registry or RunRegistry(
+            Path(self.specifications.processing.checkpoint_dir)
+        )
+        # Front half: produce PromptBatches exactly as execute() does,
+        # but stop before the LLM call.
+        prompts = self._run_front_half()
+        backend = self._build_batch_backend()
+        provider_job_id = backend.submit(prompts)
+
+        run_spec = RunSpec(
+            pipeline_id=str(self.id),
+            dataset=str(
+                self.specifications.dataset.source_path or "dataframe"
+            ),
+            spec_snapshot={
+                "pipeline_id": str(self.id),
+                "execution_mode": "provider_batch",
+                "provider": self._provider_label(),
+                "model": self.specifications.llm.model,
+                "total_prompts": int(sum(len(b.prompts) for b in prompts)),
+            },
+        )
+        handle = registry.create(run_spec)
+        # PENDING → RUNNING → SUBMITTED_REMOTE in one logical hop; the
+        # intermediate RUNNING is skipped because submit() is the whole
+        # front-half run (fast, synchronous), so the externally-visible
+        # state jumps straight to "job is with the provider".
+        registry.transition(handle.run_id, RunStatus.RUNNING)
+        registry.transition(
+            handle.run_id,
+            RunStatus.SUBMITTED_REMOTE,
+            provider_job_id=provider_job_id,
+            metrics={
+                "total_rows": int(sum(len(b.prompts) for b in prompts)),
+                "provider_job_id": provider_job_id,
+            },
+        )
+        return registry.get(handle.run_id)  # type: ignore[return-value]
+
+    @classmethod
+    def attach(
+        cls,
+        run_id: UUID,
+        *,
+        registry: RunRegistry | None = None,
+        checkpoint_dir: str | Path | None = None,
+    ) -> RunHandle:
+        """Resolve an existing batch run for polling/collection.
+
+        Returns the current :class:`RunHandle` for ``run_id`` so a
+        caller (the CLI ``collect`` command, or another process) can
+        inspect status and decide whether to drain the results. This
+        method does NOT block or collect — pair with a poll loop and
+        :meth:`collect_batch` once terminal.
+
+        Args:
+            run_id: The run to attach to (must exist in the registry).
+            registry: Open registry. If omitted, one is opened in
+                ``checkpoint_dir`` (or the default checkpoint dir).
+            checkpoint_dir: Used only when ``registry`` is None.
+        """
+        registry = registry or RunRegistry(
+            Path(checkpoint_dir) if checkpoint_dir else Path(".checkpoints")
+        )
+        handle = registry.get(run_id)
+        if handle is None:
+            raise KeyError(f"No batch run found for run_id={run_id}")
+        return handle
+
+    def _build_batch_backend(self) -> "ProviderBatchBackend":
+        """Construct the ProviderBatchBackend from this pipeline's LLMSpec."""
+        from ondine.orchestration.backends.provider_batch import (
+            ProviderBatchBackend,
+        )
+
+        return ProviderBatchBackend(llm_spec=self.specifications.llm)
+
+    def _provider_label(self) -> str:
+        provider = self.specifications.llm.provider
+        return provider.value if hasattr(provider, "value") else str(provider)
+
+    def _run_front_half(self) -> list:
+        """Execute Load → Format → Aggregate and return the PromptBatches.
+
+        Mirrors the first half of ``_execute_stages_with_tracking`` but
+        stops before the LLM invocation — exactly the boundary where
+        batch mode swaps in the ProviderBatchBackend. Kept separate so
+        the working live path in ``execute()`` is untouched.
+        """
+        specs = self.specifications
+        context = ExecutionContext(pipeline_id=self.id)
+
+        loader = DataLoaderStage(self.dataframe)
+        df = loader.process(specs.dataset, context)
+
+        formatter = PromptFormatterStage(
+            specs.processing.batch_size, use_jinja2=specs.processing.use_jinja2
+        )
+        batches = formatter.process((df, specs.prompt), context)
+
+        if specs.prompt.batch_size > 1:
+            from ondine.strategies.json_batch_strategy import JsonBatchStrategy
+
+            aggregator = BatchAggregatorStage(
+                batch_size=specs.prompt.batch_size,
+                strategy=JsonBatchStrategy(),
+                model=specs.llm.model,
+                validate_context_window=False,
+            )
+            batches = aggregator.process(batches, context)
+        return batches
 
 
 def _build_rate_limiter(processing_spec):

--- a/ondine/api/pipeline_builder.py
+++ b/ondine/api/pipeline_builder.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -667,6 +667,32 @@ class PipelineBuilder:
             Groq supports high concurrency (~100), while OpenAI free tier is limited to ~5.
         """
         self._processing_spec.concurrency = threads
+        return self
+
+    def with_execution_mode(
+        self, mode: Literal["live", "provider_batch"]
+    ) -> PipelineBuilder:
+        """Select the pipeline's execution mode (§3, §5).
+
+        * ``"live"`` (default) — one HTTP call per prompt through the
+          asyncio engine. Byte-identical to every prior version.
+        * ``"provider_batch"`` — compile prompts to JSONL, submit a
+          provider-native Batch API job (OpenAI/Anthropic), and collect
+          results later via :meth:`Pipeline.submit` /
+          :meth:`Pipeline.attach`. Non-blocking; designed for very large
+          or offline workloads where 50% batch discounts matter.
+
+        The scope guard in :meth:`build` rejects ``provider_batch`` for
+        providers without Batch API support (v1: OpenAI + Anthropic
+        only) so misconfiguration is caught at build time, not mid-run.
+
+        Args:
+            mode: ``"live"`` or ``"provider_batch"``.
+
+        Returns:
+            Self for chaining.
+        """
+        self._processing_spec.execution_mode = mode
         return self
 
     def with_adaptive_concurrency(self, enabled: bool = True) -> PipelineBuilder:
@@ -1781,6 +1807,31 @@ class PipelineBuilder:
             raise ValueError(
                 "LLM spec is required. Call with_llm() or with_custom_llm_client() before build()."
             )
+
+        # Scope guard (§5): provider_batch mode is only supported for
+        # providers with a Batch API backend (v1: OpenAI + Anthropic).
+        # Catching it here — the single user-facing choke point — means a
+        # misconfigured run fails immediately with a clear message rather
+        # than crashing deep in the JSONL submit path later.
+        if self._processing_spec.execution_mode == "provider_batch":
+            from ondine.orchestration.backends.provider_batch import (
+                SUPPORTED_BATCH_PROVIDERS,
+                ProviderBatchBackend,
+            )
+            provider_key = ProviderBatchBackend._provider_key(llm_spec)
+            if provider_key not in SUPPORTED_BATCH_PROVIDERS:
+                provider_label = (
+                    llm_spec.provider.value
+                    if hasattr(llm_spec.provider, "value")
+                    else llm_spec.provider
+                )
+                raise ValueError(
+                    f"execution_mode='provider_batch' is only supported for "
+                    f"{sorted(SUPPORTED_BATCH_PROVIDERS)} in v1, but the "
+                    f"configured provider is '{provider_label}'. Either "
+                    f"switch to an OpenAI/Anthropic provider or use "
+                    f"execution_mode='live'."
+                )
 
         specifications = PipelineSpecifications(
             dataset=self._dataset_spec,

--- a/ondine/cli/main.py
+++ b/ondine/cli/main.py
@@ -1200,6 +1200,21 @@ def collect(run_id: str, checkpoint_dir: Path, output: Path | None):
             )
             sys.exit(1)
 
+        # Guard against live-* job ids: live results live only in the
+        # submitting process's memory and cannot be rebuilt in this fresh
+        # collect process (unlike batch jobs, which are reconstructed from
+        # the spec snapshot). Without this guard, collect would rebuild an
+        # empty ProviderBatchBackend, find nothing for the live id, and
+        # silently report "Collected 0 responses".
+        if str(handle.provider_job_id).startswith("live-"):
+            console.print(
+                f"[red]❌ Run {run_id} is a live run (job "
+                f"{handle.provider_job_id}). Live results are returned "
+                "synchronously during execution and cannot be collected "
+                "separately — use the output from the original run.[/red]"
+            )
+            sys.exit(1)
+
         if handle.status.value not in (
             "submitted_remote",
             "succeeded",

--- a/ondine/cli/main.py
+++ b/ondine/cli/main.py
@@ -1045,5 +1045,219 @@ def list_providers():
         sys.exit(1)
 
 
+# ── Provider-batch commands (§5): submit / status / collect ──────────
+
+
+@cli.command()
+@click.option(
+    "--config",
+    "-c",
+    required=True,
+    type=click.Path(exists=True, path_type=Path),
+    help="Path to YAML/JSON configuration file",
+)
+@click.option(
+    "--input",
+    "-i",
+    required=True,
+    type=click.Path(exists=True, path_type=Path),
+    help="Path to input data file",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(path_type=Path),
+    help="Path for the output file (used later by collect)",
+)
+@click.option(
+    "--checkpoint-dir",
+    type=click.Path(path_type=Path),
+    default=Path(".checkpoints"),
+    help="Directory holding the run registry (default: .checkpoints)",
+)
+def submit(
+    config: Path,
+    input: Path,
+    output: Path | None,
+    checkpoint_dir: Path,
+):
+    """Submit a provider-batch job and return immediately (non-blocking).
+
+    The run is tracked in the registry; poll with ``ondine status`` and
+    drain with ``ondine collect``. Requires execution_mode=provider_batch
+    in the config (or it is forced on automatically).
+    """
+    try:
+        specs = _load_specs_from_config(config)
+        specs.dataset.source_path = input
+        if output is not None:
+            _apply_output_override(specs, output)
+        # Force batch mode — the command exists for batch users.
+        specs.processing.execution_mode = "provider_batch"
+
+        pipeline = Pipeline(specs)
+        from ondine.orchestration import RunRegistry
+
+        registry = RunRegistry(checkpoint_dir)
+        handle = pipeline.submit(registry=registry)
+
+        console.print("[green]✓ Batch job submitted[/green]")
+        console.print(f"  run_id          : [cyan]{handle.run_id}[/cyan]")
+        console.print(
+            f"  provider_job_id : [cyan]{handle.provider_job_id}[/cyan]"
+        )
+        console.print(f"  status          : {handle.status.value}")
+        console.print(
+            "\n  [dim]Poll with: ondine status "
+            f"{handle.run_id}[/dim]\n"
+        )
+    except ValueError as e:
+        console.print(f"[red]❌ {e}[/red]")
+        sys.exit(1)
+    except Exception as e:  # noqa: BLE001
+        console.print(f"[red]❌ Error: {e}[/red]")
+        sys.exit(1)
+
+
+@cli.command()
+@click.argument("run_id")
+@click.option(
+    "--checkpoint-dir",
+    type=click.Path(path_type=Path),
+    default=Path(".checkpoints"),
+    help="Directory holding the run registry (default: .checkpoints)",
+)
+def status(run_id: str, checkpoint_dir: Path):
+    """Poll the live status of a batch run."""
+    try:
+        from ondine.orchestration import RunRegistry
+
+        registry = RunRegistry(checkpoint_dir)
+        handle = registry.get(UUID(run_id))
+        if handle is None:
+            console.print(f"[red]❌ Unknown run_id: {run_id}[/red]")
+            sys.exit(1)
+
+        metrics = handle.metrics or {}
+        total = metrics.get("total_rows", 0) or 0
+        done = metrics.get("processed_rows", metrics.get("rows_done", 0)) or 0
+        progress_pct = (done / total * 100) if total else 0.0
+
+        table = Table(title=f"Run {run_id}", show_header=True)
+        table.add_column("Field", style="cyan", width=20)
+        table.add_column("Value", style="white", width=40)
+        table.add_row("status", handle.status.value)
+        table.add_row("provider_job_id", str(handle.provider_job_id))
+        table.add_row("progress", f"{progress_pct:.1f}%")
+        table.add_row("rows_done", str(done))
+        table.add_row("total_rows", str(total))
+        table.add_row("cost", str(metrics.get("cost", "0")))
+        table.add_row("updated_at", handle.updated_at)
+        console.print(table)
+    except ValueError as e:
+        console.print(f"[red]❌ {e}[/red]")
+        sys.exit(1)
+    except Exception as e:  # noqa: BLE001
+        console.print(f"[red]❌ Error: {e}[/red]")
+        sys.exit(1)
+
+
+@cli.command()
+@click.argument("run_id")
+@click.option(
+    "--checkpoint-dir",
+    type=click.Path(path_type=Path),
+    default=Path(".checkpoints"),
+    help="Directory holding the run registry (default: .checkpoints)",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(path_type=Path),
+    help="Write collected results to this file",
+)
+def collect(run_id: str, checkpoint_dir: Path, output: Path | None):
+    """Collect the results of a finished batch run.
+
+    Polls until the provider job is terminal, downloads and decodes the
+    results, then writes them to ``--output`` (if given). Refuses an
+    in-flight run — use ``ondine status`` first.
+    """
+    try:
+        from ondine.orchestration import RunRegistry
+        from ondine.orchestration.run_registry import RunStatus
+
+        registry = RunRegistry(checkpoint_dir)
+        handle = registry.get(UUID(run_id))
+        if handle is None:
+            console.print(f"[red]❌ Unknown run_id: {run_id}[/red]")
+            sys.exit(1)
+
+        if handle.provider_job_id is None:
+            console.print(
+                f"[red]❌ Run {run_id} has no provider_job_id "
+                "(not a batch run).[/red]"
+            )
+            sys.exit(1)
+
+        if handle.status.value not in (
+            "submitted_remote",
+            "succeeded",
+            "failed",
+            "partial",
+        ):
+            console.print(
+                f"[red]❌ Run {run_id} status is {handle.status.value}; "
+                "cannot collect.[/red]"
+            )
+            sys.exit(1)
+
+        # Rebuild the backend from the snapshot so collect works in a
+        # fresh process (the submit process need not still be running).
+        from ondine.core.specifications import LLMSpec
+        from ondine.orchestration.backends.provider_batch import (
+            ProviderBatchBackend,
+        )
+
+        snapshot = handle.spec_snapshot or {}
+        llm_spec = LLMSpec(
+            provider=snapshot.get("provider", "openai"),
+            model=snapshot.get("model", "gpt-4o-mini"),
+        )
+        backend = ProviderBatchBackend(llm_spec=llm_spec)
+
+        console.print(
+            f"[cyan]Collecting results for provider job "
+            f"{handle.provider_job_id}...[/cyan]"
+        )
+        responses = list(backend.collect(handle.provider_job_id))
+        registry.transition(
+            handle.run_id,
+            RunStatus.SUCCEEDED,
+            metrics={
+                "processed_rows": len(responses),
+                "rows_done": len(responses),
+            },
+        )
+
+        console.print(
+            f"[green]✓ Collected {len(responses)} responses[/green]"
+        )
+        if output is not None:
+            import pandas as pd
+
+            df = pd.DataFrame(
+                [{"text": r.text, "tokens_in": r.tokens_in} for r in responses]
+            )
+            df.to_csv(output, index=False)
+            console.print(f"  wrote: [cyan]{output}[/cyan]")
+    except ValueError as e:
+        console.print(f"[red]❌ {e}[/red]")
+        sys.exit(1)
+    except Exception as e:  # noqa: BLE001
+        console.print(f"[red]❌ Error: {e}[/red]")
+        sys.exit(1)
+
+
 if __name__ == "__main__":
     cli()

--- a/ondine/core/specifications.py
+++ b/ondine/core/specifications.py
@@ -9,7 +9,7 @@ components, following the principle of separation between configuration
 from decimal import Decimal
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -496,6 +496,32 @@ class ProcessingSpec(BaseModel):
         description="Delete checkpoints after successful execution. "
         "Set False to keep checkpoints as a safety net against downstream failures.",
     )
+
+    # Execution mode — selects the pipeline's middle stage (§3, §5).
+    # "live" (default): one synchronous/async HTTP call per prompt via the
+    # existing asyncio engine — byte-identical to every prior version.
+    # "provider_batch": compile prompts to JSONL, submit a provider-native
+    # Batch API job (OpenAI/Anthropic), and collect results later. Enables
+    # non-blocking submit → poll → collect for very large/offline workloads.
+    # The scope guard in PipelineBuilder.build() rejects unsupported providers.
+    execution_mode: Literal["live", "provider_batch"] = Field(
+        default="live",
+        description=(
+            "Execution mode: 'live' (default, per-call HTTP) or "
+            "'provider_batch' (OpenAI/Anthropic Batch API, non-blocking)."
+        ),
+    )
+
+    @field_validator("execution_mode")
+    @classmethod
+    def validate_execution_mode(cls, v: str) -> str:
+        """Restrict to the two supported modes; fail fast on typos."""
+        allowed = {"live", "provider_batch"}
+        if v not in allowed:
+            raise ValueError(
+                f"execution_mode must be one of {sorted(allowed)}, got '{v}'"
+            )
+        return v
 
     @field_validator("checkpoint_dir")
     @classmethod

--- a/ondine/mcp/__init__.py
+++ b/ondine/mcp/__init__.py
@@ -1,0 +1,25 @@
+"""Ondine MCP server (L5 front door).
+
+Exposes four pipeline operations as MCP tools (ondine_estimate, ondine_run,
+ondine_status, ondine_collect). Requires the ``ondine[mcp]`` extra (FastMCP).
+See :mod:`ondine.mcp.server` for the implementation.
+"""
+
+from ondine.mcp.progress import RegistryProgressObserver
+
+
+def __getattr__(name: str):
+    # Lazy: importing the package does not require fastmcp; only building the
+    # server does. This keeps `import ondine.mcp` cheap and dep-free.
+    if name == "MCPService":
+        from ondine.mcp.server import MCPService
+
+        return MCPService
+    if name == "create_server":
+        from ondine.mcp.server import create_server
+
+        return create_server
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["MCPService", "create_server", "RegistryProgressObserver"]

--- a/ondine/mcp/progress.py
+++ b/ondine/mcp/progress.py
@@ -1,0 +1,130 @@
+"""Bridge from pipeline execution progress to the RunRegistry.
+
+The MCP ``ondine_status`` tool needs live rows-done and cost-so-far for a
+RUNNING job. That data flows through :class:`ExecutionContext` during
+execution; this module is the :class:`ExecutionObserver` that copies the
+relevant counters onto the durable :class:`RunRegistry` row so a status poller
+(even in another process) sees them.
+
+Design (information hiding):
+
+* The observer knows two things: which ``run_id`` it serves, and which
+  registry to write to. It does not know what a "stage" is, how cost is
+  accumulated, or what transport reads it back. It is a pure forwarder.
+* Writes are best-effort and throttled: progress churns on every batch, and a
+  registry write per batch would be needlessly expensive and would spam the
+  WAL. A minimum interval between writes collapses the burst while keeping
+  status fresh enough for human-scale polling.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from ondine.orchestration.observers import ExecutionObserver
+
+if TYPE_CHECKING:
+    from ondine.orchestration.execution_context import ExecutionContext
+    from ondine.orchestration.run_registry import RunRegistry
+    from ondine.stages.pipeline_stage import PipelineStage
+
+
+class RegistryProgressObserver(ExecutionObserver):
+    """Forward live execution progress to a RunRegistry row.
+
+    Attached to a :class:`~ondine.api.pipeline.Pipeline` via
+    ``pipeline.add_observer(...)`` before ``execute(run_id=..., registry=...)``.
+    On every progress update it writes ``processed_rows`` and ``cost`` to the
+    registry under ``run_id`` using :meth:`RunRegistry.update_metrics`, which
+    persists without changing status (status transitions are the pipeline's
+    job).
+
+    Throttling: writes are collapsed to at most one per ``min_interval``
+    seconds (default 0.25s) so a fast run does not write the WAL on every row.
+    """
+
+    def __init__(
+        self,
+        registry: RunRegistry,
+        run_id: Any,
+        min_interval: float = 0.25,
+    ) -> None:
+        self._registry = registry
+        self._run_id = run_id
+        self._min_interval = min_interval
+        self._last_write: float = 0.0
+        self._last_rows: int = -1
+
+    # ── ExecutionObserver interface ─────────────────────────────────
+
+    def on_pipeline_start(self, pipeline: Any, context: ExecutionContext) -> None:
+        self._flush(context)
+
+    def on_stage_start(self, stage: PipelineStage, context: ExecutionContext) -> None:
+        pass  # progress is reported via on_progress_update / on_stage_complete
+
+    def on_stage_complete(
+        self, stage: PipelineStage, context: ExecutionContext, result: Any
+    ) -> None:
+        self._flush(context)
+
+    def on_stage_error(
+        self,
+        stage: PipelineStage,
+        context: ExecutionContext,
+        error: Exception,
+    ) -> None:
+        self._flush(context)
+
+    def on_pipeline_complete(self, context: ExecutionContext, result: Any) -> None:
+        # Final flush with the authoritative end state — bypass the throttle.
+        self._write(
+            processed_rows=int(getattr(context, "last_processed_row", 0)),
+            total_rows=int(getattr(context, "total_rows", 0)),
+            cost=context.run_progress.snapshot_cost,
+            force=True,
+        )
+
+    def on_pipeline_error(self, context: ExecutionContext, error: Exception) -> None:
+        self._flush(context, force=True)
+
+    def on_progress_update(self, context: ExecutionContext) -> None:
+        self._flush(context)
+
+    # ── internals ───────────────────────────────────────────────────
+
+    def _flush(self, context: ExecutionContext, force: bool = False) -> None:
+        rows = int(getattr(context, "last_processed_row", 0))
+        # Skip if rows haven't advanced since the last write (no new info).
+        if not force and rows == self._last_rows:
+            return
+        self._write(
+            processed_rows=rows,
+            total_rows=int(getattr(context, "total_rows", 0)),
+            cost=context.run_progress.snapshot_cost,
+            force=force,
+        )
+
+    def _write(
+        self,
+        processed_rows: int,
+        total_rows: int,
+        cost: Any,
+        force: bool = False,
+    ) -> None:
+        now = time.monotonic()
+        if not force and (now - self._last_write) < self._min_interval:
+            return
+        self._last_write = now
+        self._last_rows = processed_rows
+        metrics: dict[str, Any] = {"processed_rows": processed_rows, "cost": str(cost)}
+        if total_rows:
+            metrics["total_rows"] = total_rows
+        try:
+            self._registry.update_metrics(self._run_id, metrics)
+        except Exception:  # noqa: BLE001
+            # A registry write failure must never kill the run. The terminal
+            # transition (written by Pipeline.execute) is the source of truth
+            # for final state; live-progress writes are best-effort.
+            pass

--- a/ondine/mcp/server.py
+++ b/ondine/mcp/server.py
@@ -1,0 +1,473 @@
+"""ondine MCP server — an L5 front door exposing pipeline ops as MCP tools.
+
+Architecture (see /plans/ARCHITECTURE_PROPOSAL.md §4):
+
+* This module sits at L5 (front door). It imports only L4 (Pipeline) and
+  ondine.config — never stages or engines. The four tools are thin façades.
+* ``ondine_run`` hands back a ``run_id`` immediately and runs the pipeline on a
+  daemon thread, writing progress to the shared RunRegistry (§2). A second
+  tool call (``ondine_status`` / ``ondine_collect``) — even from another
+  process — reads the durable registry row to report live progress and final
+  results.
+* A budget cap is MANDATORY on every ``ondine_run``: the whole point of
+  exposing dataset processing to an LLM tool client is that the caller may not
+  understand the cost implications, so the server refuses to launch without an
+  explicit ceiling and injects it into the processing spec so the engine's own
+  BudgetController enforces it end-to-end.
+
+The MCP wire layer (FastMCP 3.x) is a pass-through: ``create_server()`` decorates
+the four ``MCPService`` methods and returns the app; all behaviour lives in
+:class:`MCPService` so it is directly unit-testable without an MCP client.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from decimal import Decimal
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from ondine.api.pipeline import Pipeline
+from ondine.config.config_loader import ConfigLoader
+from ondine.mcp.progress import RegistryProgressObserver
+from ondine.utils import get_logger
+from ondine.utils.optional_dependencies import _matches_missing_dependency
+
+if TYPE_CHECKING:
+    from ondine.orchestration.run_registry import (
+        RunHandle,
+        RunRegistry,
+        RunStatus,
+    )
+
+logger = get_logger(__name__)
+
+
+def _require_fastmcp() -> Any:
+    """Import FastMCP lazily so importing this module never forces the extra.
+
+    The ``ondine[mcp]`` extra installs ``fastmcp``; users who never run the
+    server should not pay the import cost or see an import error. This helper
+    raises a clear, actionable error pointing at the extra on missing dep.
+    """
+    try:
+        from fastmcp import FastMCP
+    except ImportError as exc:
+        if _matches_missing_dependency(exc, ("fastmcp", "mcp")):
+            raise ImportError(
+                "The ondine MCP server requires the 'mcp' extra. "
+                "Install with: pip install 'ondine[mcp]'"
+            ) from exc
+        raise
+    return FastMCP
+
+
+class MCPService:
+    """Plain-Python implementation of the four MCP tools.
+
+    Every method maps 1:1 to an MCP tool (``ondine_estimate`` →
+    :meth:`ondine_estimate`, etc.). Keeping the logic in a transport-agnostic
+    class means the behaviour is fully testable without spinning up an MCP
+    client, and the FastMCP layer in :func:`create_server` is a trivial
+    decorator pass-through.
+
+    State held across calls:
+
+    * ``_registry`` — the shared :class:`RunRegistry` (§2). This is the
+      cross-call (and cross-process) channel for run identity, status, and
+      live progress. It is the *only* durable state the service owns.
+    * ``_threads`` — in-process background workers keyed by run_id. v1 runs
+      jobs on a daemon thread of the server process; the registry's on-disk
+      row means a crash or restart still leaves a resumable checkpoint and a
+      discoverable run_id. True out-of-process workers are §3's scope.
+    """
+
+    def __init__(
+        self,
+        registry_dir: str | Path | None = None,
+        registry: RunRegistry | None = None,
+    ) -> None:
+        if registry is not None:
+            self._registry = registry
+            self._owns_registry = False
+        else:
+            from ondine.orchestration.run_registry import RunRegistry
+
+            reg_dir = (
+                Path(registry_dir) if registry_dir is not None else Path(".checkpoints")
+            )
+            reg_dir.mkdir(parents=True, exist_ok=True)
+            self._registry = RunRegistry(reg_dir)
+            self._owns_registry = True
+        self._threads: dict[str, threading.Thread] = {}
+
+    # ── ondine_estimate ─────────────────────────────────────────────
+
+    def ondine_estimate(
+        self,
+        config_yaml: str,
+        sample_rows: int | None = None,
+    ) -> dict[str, Any]:
+        """Estimate cost/token/row counts for a config WITHOUT running.
+
+        Side-effect-free: builds a Pipeline purely to call ``estimate_cost()``,
+        never touches the registry and never writes a checkpoint.
+        """
+        pipeline = self._build_pipeline(config_yaml)
+        estimate = pipeline.estimate_cost()
+        return {
+            "total_cost": str(estimate.total_cost),
+            "total_tokens": estimate.total_tokens,
+            "input_tokens": estimate.input_tokens,
+            "output_tokens": estimate.output_tokens,
+            "rows": estimate.rows,
+            "confidence": estimate.confidence,
+        }
+
+    # ── ondine_run ──────────────────────────────────────────────────
+
+    def ondine_run(
+        self,
+        config_yaml: str,
+        input_path: str,
+        output_path: str,
+        budget: float | Decimal | str | None,
+    ) -> dict[str, Any]:
+        """Launch a pipeline run, returning ``run_id`` immediately.
+
+        ``budget`` is MANDATORY and must be positive — an LLM tool client must
+        not be able to launch an unbounded-spend job. The budget is injected
+        into the processing spec so the engine's BudgetController enforces it,
+        and persisted in the run's spec snapshot for audit.
+        """
+        budget_decimal = self._require_positive_budget(budget)
+
+        pipeline = self._build_pipeline(config_yaml)
+        # Inject the mandatory budget into the spec the engine will actually
+        # run, so the BudgetController caps spend at the source.
+        pipeline.specifications.processing.max_budget = budget_decimal
+
+        # Override I/O paths from the tool arguments (they are the source of
+        # truth for an MCP call, superseding whatever the YAML carried).
+        pipeline.specifications.dataset.source_path = Path(input_path)
+        self._apply_output(pipeline, Path(output_path))
+
+        # Register the run BEFORE launching so the id is durable even if the
+        # worker thread fails to start. The snapshot carries the budget for
+        # audit and the input/output paths for collect().
+        spec_snapshot = pipeline.specifications.model_dump(mode="json")
+        spec_snapshot.setdefault("_mcp", {})
+        spec_snapshot["_mcp"].update(
+            {"input_path": str(input_path), "output_path": str(output_path)}
+        )
+        from ondine.orchestration.run_registry import RunSpec
+
+        run_spec = RunSpec(
+            pipeline_id=str(pipeline.id),
+            dataset=str(input_path),
+            spec_snapshot=spec_snapshot,
+        )
+        handle = self._registry.create(run_spec)
+        run_id_str = str(handle.run_id)
+
+        # Wire pipeline progress → registry so ondine_status sees live rows/cost.
+        pipeline.add_observer(RegistryProgressObserver(self._registry, handle.run_id))
+
+        # Run on a daemon thread: the call returns the run_id now; the thread
+        # drives the registry through RUNNING → SUCCEEDED|FAILED.
+        thread = threading.Thread(
+            target=self._run_worker,
+            name=f"ondine-mcp-{run_id_str[:8]}",
+            args=(pipeline, handle.run_id),
+            daemon=True,
+        )
+        self._threads[run_id_str] = thread
+        thread.start()
+        return {"run_id": run_id_str}
+
+    # ── ondine_status ───────────────────────────────────────────────
+
+    def ondine_status(self, run_id: str) -> dict[str, Any]:
+        """Live status: state, progress %, rows done, cost so far."""
+        handle = self._registry.get(_to_uuid(run_id))
+        if handle is None:
+            raise KeyError(f"Unknown run_id: {run_id}")
+        metrics = handle.metrics or {}
+        total = metrics.get("total_rows", 0) or 0
+        done = metrics.get("processed_rows", metrics.get("rows_done", 0)) or 0
+        progress_pct = (done / total * 100) if total else 0.0
+        return {
+            "run_id": str(handle.run_id),
+            "status": handle.status.value,
+            "progress_pct": round(progress_pct, 2),
+            "rows_done": done,
+            "total_rows": total,
+            "cost": str(metrics.get("cost", "0")),
+            "updated_at": handle.updated_at,
+        }
+
+    # ── ondine_collect ──────────────────────────────────────────────
+
+    def ondine_collect(self, run_id: str) -> dict[str, Any]:
+        """Terminal readout: rows, cost, and the output path.
+
+        Refuses a non-terminal run so a caller never gets a half-written
+        summary. Use :meth:`ondine_status` to follow an in-flight run.
+        """
+        handle = self._registry.get(_to_uuid(run_id))
+        if handle is None:
+            raise KeyError(f"Unknown run_id: {run_id}")
+        if handle.status.value not in ("succeeded", "failed", "partial"):
+            raise ValueError(
+                f"Run {run_id} is not finished (status={handle.status.value}); "
+                "poll ondine_status until terminal."
+            )
+        metrics = handle.metrics or {}
+        mcp_meta = (handle.spec_snapshot or {}).get("_mcp", {})
+        output_path = mcp_meta.get("output_path") or metrics.get("output_path", "")
+        return {
+            "run_id": str(handle.run_id),
+            "status": handle.status.value,
+            "rows_done": metrics.get("processed_rows", metrics.get("rows_done", 0)),
+            "total_rows": metrics.get("total_rows", 0),
+            "cost": str(metrics.get("cost", "0")),
+            "output_path": str(output_path),
+            "error": metrics.get("error"),
+            "updated_at": handle.updated_at,
+        }
+
+    # ── convenience / test seams ────────────────────────────────────
+
+    def list_runs(self) -> list[RunHandle]:
+        """List all known runs (newest-first), for inspection/testing."""
+        return self._registry.list()
+
+    def get_spec_snapshot(self, run_id: str) -> dict[str, Any] | None:
+        handle = self._registry.get(_to_uuid(run_id))
+        return dict(handle.spec_snapshot) if handle is not None else None
+
+    def wait_and_collect(self, run_id: str, timeout: float = 60.0) -> dict[str, Any]:
+        """Block until the run is terminal, then return :meth:`ondine_collect`.
+
+        Convenience for tests and synchronous callers; the MCP tool itself
+        never blocks (ondine_run returns immediately).
+        """
+        import time
+
+        uid = _to_uuid(run_id)
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            handle = self._registry.get(uid)
+            if handle is not None and handle.status.value in (
+                "succeeded",
+                "failed",
+                "partial",
+            ):
+                return self.ondine_collect(run_id)
+            time.sleep(0.05)
+        raise TimeoutError(f"Run {run_id} did not finish within {timeout}s")
+
+    def _seed_pending_run(self) -> RunHandle:
+        """Create a PENDING run with no worker — a test seam for asserting
+        that ondine_collect refuses an in-flight run."""
+        from ondine.orchestration.run_registry import RunSpec
+
+        return self._registry.create(RunSpec(pipeline_id="test-seed", dataset="seed"))
+
+    def close(self) -> None:
+        if self._owns_registry:
+            self._registry.close()
+
+    # ── internals ───────────────────────────────────────────────────
+
+    @staticmethod
+    def _require_positive_budget(
+        budget: float | Decimal | str | None,
+    ) -> Decimal:
+        if budget is None:
+            raise ValueError(
+                "A budget cap is mandatory for ondine_run. Pass a positive "
+                "budget (USD) to set the maximum spend for this run."
+            )
+        try:
+            dec = Decimal(str(budget))
+        except Exception as exc:  # noqa: BLE001
+            raise ValueError(f"Budget must be a number, got {budget!r}") from exc
+        if dec <= 0:
+            raise ValueError(
+                f"Budget must be positive (got {dec}); an MCP run cannot be "
+                "launched without a spend ceiling."
+            )
+        return dec
+
+    @staticmethod
+    def _build_pipeline(config_yaml: str) -> Pipeline:
+        """Parse a YAML/JSON config string into a Pipeline (no execution).
+
+        Reuses ConfigLoader so MCP and CLI accept identical config shapes.
+        """
+        config_dict = yaml.safe_load(config_yaml)
+        if not isinstance(config_dict, dict):
+            raise ValueError(
+                "config_yaml must parse to a mapping (dict); got "
+                f"{type(config_dict).__name__}"
+            )
+        specs = ConfigLoader._dict_to_specifications(config_dict)  # noqa: SLF001
+        return Pipeline(specs)
+
+    @staticmethod
+    def _apply_output(pipeline: Pipeline, output_path: Path) -> None:
+        from ondine.core.specifications import (
+            DataSourceType,
+            MergeStrategy,
+            OutputSpec,
+        )
+
+        suffix = output_path.suffix.lower()
+        dst_type = {
+            ".csv": DataSourceType.CSV,
+            ".json": DataSourceType.CSV,
+            ".parquet": DataSourceType.PARQUET,
+            ".xlsx": DataSourceType.EXCEL,
+            ".xls": DataSourceType.EXCEL,
+        }.get(suffix, DataSourceType.CSV)
+        pipeline.specifications.output = OutputSpec(
+            destination_type=dst_type,
+            destination_path=output_path,
+            merge_strategy=MergeStrategy.REPLACE,
+        )
+
+    def _run_worker(self, pipeline: Pipeline, run_id: uuid.UUID) -> None:
+        """Background worker: drive the registry through the run lifecycle.
+
+        Errors are swallowed here (and recorded as FAILED in the registry by
+        Pipeline.execute itself) so a failing worker never crashes the server
+        process or leaves the thread pool in a bad state.
+        """
+
+        # Re-derive total rows for progress math before execute mutates state.
+        try:
+            loader_df = pipeline.dataframe
+            if loader_df is None and pipeline.specifications.dataset.source_path:
+                import pandas as pd
+
+                loader_df = pd.read_csv(pipeline.specifications.dataset.source_path)
+            total_rows = int(len(loader_df)) if loader_df is not None else 0
+            self._registry.update_metrics(run_id, {"total_rows": total_rows})
+        except Exception:  # noqa: BLE001
+            # Non-fatal: progress % will just read 0 total until the observer
+            # writes the real count. Don't block the run on row-count math.
+            pass
+
+        try:
+            pipeline.execute(run_id=run_id, registry=self._registry)
+        except Exception as exc:  # noqa: BLE001
+            # Pipeline.execute already recorded FAILED in the registry; this
+            # guard is for failures in the thread plumbing itself.
+            logger.exception("ondine_run worker for %s crashed", run_id)
+            try:
+                self._registry.transition(
+                    run_id,
+                    self._terminal_for(run_id),
+                    metrics={"error": f"{type(exc).__name__}: {exc}"},
+                )
+            except Exception:  # noqa: BLE001
+                pass
+        finally:
+            self._threads.pop(str(run_id), None)
+
+    def _terminal_for(self, run_id: uuid.UUID) -> RunStatus:
+        """Pick a legal terminal status from the run's current state."""
+        from ondine.orchestration.run_registry import RunStatus
+
+        handle = self._registry.get(run_id)
+        if handle is not None and handle.status is RunStatus.PENDING:
+            return RunStatus.FAILED  # PENDING can only move to RUNNING or FAILED
+        return RunStatus.FAILED
+
+
+def _to_uuid(run_id: str) -> uuid.UUID:
+    try:
+        return uuid.UUID(str(run_id))
+    except (ValueError, TypeError) as exc:
+        raise KeyError(f"Invalid run_id (not a UUID): {run_id!r}") from exc
+
+
+def create_server(service: MCPService | None = None) -> Any:
+    """Build the FastMCP app with the four ondine tools registered.
+
+    Returns the FastMCP instance; call ``.run()`` (stdio) to serve. Importing
+    this function does not import FastMCP — only calling it does — so users
+    without the ``ondine[mcp]`` extra can still import the rest of ondine.
+    """
+    fastmcp_cls = _require_fastmcp()
+    svc = service if service is not None else MCPService()
+    mcp = fastmcp_cls("ondine")
+
+    @mcp.tool(
+        name="ondine_estimate",
+        description=(
+            "Estimate the cost, token usage, and row count for an ondine "
+            "pipeline configuration WITHOUT running it. Fast and side-effect "
+            "-free. Pass the full config as a YAML string."
+        ),
+    )
+    def _estimate(
+        config_yaml: str,
+        sample_rows: int | None = None,
+    ) -> dict[str, Any]:
+        return svc.ondine_estimate(config_yaml, sample_rows)
+
+    @mcp.tool(
+        name="ondine_run",
+        description=(
+            "Launch an ondine pipeline run. Returns run_id immediately — the "
+            "job runs in the background; poll ondine_status for progress and "
+            "call ondine_collect once it finishes. A positive budget (USD) is "
+            "MANDATORY and caps total spend."
+        ),
+    )
+    def _run(
+        config_yaml: str,
+        input_path: str,
+        output_path: str,
+        budget: float,
+    ) -> dict[str, Any]:
+        return svc.ondine_run(config_yaml, input_path, output_path, budget)
+
+    @mcp.tool(
+        name="ondine_status",
+        description=(
+            "Poll the live status of an ondine run: state, progress %, rows "
+            "done, and cost so far. Returns 'unknown run_id' if the id was "
+            "never created."
+        ),
+    )
+    def _status(run_id: str) -> dict[str, Any]:
+        return svc.ondine_status(run_id)
+
+    @mcp.tool(
+        name="ondine_collect",
+        description=(
+            "Collect the final result of a finished ondine run: rows, cost, "
+            "the output file path, and any error. Refuses a still-running run "
+            "(poll ondine_status first)."
+        ),
+    )
+    def _collect(run_id: str) -> dict[str, Any]:
+        return svc.ondine_collect(run_id)
+
+    return mcp
+
+
+def main() -> None:
+    """Console-script entrypoint: ``ondine-mcp`` serves over stdio."""
+    server = create_server()
+    server.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/ondine/orchestration/__init__.py
+++ b/ondine/orchestration/__init__.py
@@ -22,6 +22,14 @@ from ondine.orchestration.progress_tracker import (
     RichProgressTracker,
     create_progress_tracker,
 )
+from ondine.orchestration.run_registry import (
+    REGISTRY_FILENAME,
+    RegistryObserver,
+    RunHandle,
+    RunRegistry,
+    RunSpec,
+    RunStatus,
+)
 from ondine.orchestration.state_manager import StateManager
 from ondine.orchestration.streaming_executor import (
     StreamingExecutor,
@@ -56,6 +64,13 @@ __all__ = [
     "ConcurrencyController",
     "DeploymentTracker",
     "ProgressReporter",
+    # Run registry — persistent cross-process job index
+    "RunRegistry",
+    "RunHandle",
+    "RunSpec",
+    "RunStatus",
+    "RegistryObserver",
+    "REGISTRY_FILENAME",
     # Streaming processing (for large datasets)
     "StreamingProcessor",
     "StreamingStats",

--- a/ondine/orchestration/__init__.py
+++ b/ondine/orchestration/__init__.py
@@ -1,6 +1,12 @@
 """Orchestration engine for pipeline execution control."""
 
 from ondine.orchestration.async_executor import AsyncExecutor
+from ondine.orchestration.backends import (
+    BatchProgress,
+    ExecutionBackend,
+    ProviderBatchBackend,
+    SUPPORTED_BATCH_PROVIDERS,
+)
 from ondine.orchestration.concurrency_controller import ConcurrencyController
 from ondine.orchestration.deployment_tracker import DeploymentTracker
 from ondine.orchestration.execution_context import (
@@ -71,6 +77,11 @@ __all__ = [
     "RunStatus",
     "RegistryObserver",
     "REGISTRY_FILENAME",
+    # Execution backends — pluggable middle of the pipeline (§3, §5)
+    "ExecutionBackend",
+    "BatchProgress",
+    "ProviderBatchBackend",
+    "SUPPORTED_BATCH_PROVIDERS",
     # Streaming processing (for large datasets)
     "StreamingProcessor",
     "StreamingStats",

--- a/ondine/orchestration/backends/__init__.py
+++ b/ondine/orchestration/backends/__init__.py
@@ -2,14 +2,17 @@
 
 * :class:`ExecutionBackend` (in :mod:`base`) is the protocol both live
   and batch backends satisfy.
+* :class:`LiveBackend` (in :mod:`live`) runs the existing asyncio engine
+  synchronously through the protocol's degenerate lifecycle.
 * :class:`ProviderBatchBackend` (in :mod:`provider_batch`) implements
   OpenAI + Anthropic native Batch API mode.
-* ``LiveBackend`` (moving the existing asyncio engine behind the
-  protocol) is a follow-up build step; until it lands, live runs keep
-  using the engine directly and only batch mode routes through here.
 """
 
-from ondine.orchestration.backends.base import BatchProgress, ExecutionBackend
+from ondine.orchestration.backends.base import (
+    BatchProgress,
+    ExecutionBackend,
+)
+from ondine.orchestration.backends.live import LiveBackend
 from ondine.orchestration.backends.provider_batch import (
     SUPPORTED_BATCH_PROVIDERS,
     ProviderBatchBackend,
@@ -18,6 +21,7 @@ from ondine.orchestration.backends.provider_batch import (
 __all__ = [
     "BatchProgress",
     "ExecutionBackend",
+    "LiveBackend",
     "ProviderBatchBackend",
     "SUPPORTED_BATCH_PROVIDERS",
 ]

--- a/ondine/orchestration/backends/__init__.py
+++ b/ondine/orchestration/backends/__init__.py
@@ -1,0 +1,23 @@
+"""Execution backends — the pluggable middle of the pipeline.
+
+* :class:`ExecutionBackend` (in :mod:`base`) is the protocol both live
+  and batch backends satisfy.
+* :class:`ProviderBatchBackend` (in :mod:`provider_batch`) implements
+  OpenAI + Anthropic native Batch API mode.
+* ``LiveBackend`` (moving the existing asyncio engine behind the
+  protocol) is a follow-up build step; until it lands, live runs keep
+  using the engine directly and only batch mode routes through here.
+"""
+
+from ondine.orchestration.backends.base import BatchProgress, ExecutionBackend
+from ondine.orchestration.backends.provider_batch import (
+    SUPPORTED_BATCH_PROVIDERS,
+    ProviderBatchBackend,
+)
+
+__all__ = [
+    "BatchProgress",
+    "ExecutionBackend",
+    "ProviderBatchBackend",
+    "SUPPORTED_BATCH_PROVIDERS",
+]

--- a/ondine/orchestration/backends/base.py
+++ b/ondine/orchestration/backends/base.py
@@ -1,0 +1,116 @@
+"""Execution backend protocol — the pluggable middle of the pipeline.
+
+Architecture (see /plans/ARCHITECTURE_PROPOSAL.md §3):
+
+* The front half (Load → Format → Aggregate) and the back half
+  (Disaggregate → Parse → Write) are SHARED across execution modes.
+* Only the middle — the LLM call layer — swaps. ``LiveBackend`` drives
+  the existing asyncio engine (request-per-call); ``ProviderBatchBackend``
+  compiles a JSONL, submits a provider-native Batch job, and collects
+  results later (see :mod:`ondine.orchestration.backends.provider_batch`).
+
+This module defines the contract both backends satisfy. The interface is
+**job-lifecycle shaped** (submit → poll → collect), NOT request-shaped,
+because the whole point of provider batch mode is that submit and collect
+are separated in time — a request-stream interface would force the batch
+backend to block inside ``invoke()``, destroying the non-blocking UX the
+RunRegistry and CLI depend on.
+
+Design (deep module, information hiding):
+
+* ``ExecutionBackend`` exposes the minimum a pipeline needs to route a
+  run: ``submit`` to start, ``poll`` for progress, ``collect`` for
+  results. Every provider-specific detail (JSONL encoding, batch API
+  endpoints, file upload/download, response envelope decoding) lives
+  behind the concrete backend and never reaches the caller.
+* ``BatchProgress`` is a provider-agnostic snapshot: total / completed /
+  failed counts and a terminal flag. The registry and CLI read this one
+  shape regardless of whether the job runs on OpenAI or Anthropic, so
+  adding a third provider later touches exactly one module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ondine.core.models import LLMResponse, PromptBatch
+    from ondine.core.specifications import LLMSpec
+
+
+@dataclass(frozen=True)
+class BatchProgress:
+    """Provider-agnostic snapshot of a batch job's current state.
+
+    ``total`` / ``completed`` / ``failed`` are request counts (one
+    request per prompt row). ``is_terminal`` lets a poller stop without
+    re-deriving the provider's own status vocabulary (OpenAI uses
+    ``completed``/``failed``/``expired``; Anthropic uses
+    ``ended`` — the caller should not have to know).
+    """
+
+    provider_job_id: str
+    status: str
+    total: int = 0
+    completed: int = 0
+    failed: int = 0
+    cost_so_far: Decimal = Decimal("0")
+    is_terminal: bool = False
+
+
+@runtime_checkable
+class ExecutionBackend(Protocol):
+    """Pluggable middle of the pipeline: how prompts become responses.
+
+    A backend owns ONE concern — turning a list of :class:`PromptBatch`
+    into a stream of :class:`LLMResponse` — and hides every detail of
+    the transport (live HTTP vs. provider batch job) behind three
+    methods. The pipeline's front and back halves are identical for
+    every backend; only the middle swaps.
+
+    Lifecycle:
+
+    * ``submit(prompts)`` — non-blocking. Compiles and uploads the
+      request payload, kicks off the job, returns a ``provider_job_id``
+      the caller persists (in :class:`RunHandle`) for later polling.
+    * ``poll(provider_job_id)`` — read-only progress snapshot.
+    * ``collect(provider_job_id)`` — terminal only. Downloads and
+      decodes the results, yielding one :class:`LLMResponse` per
+      original request, ordered to match the submit order.
+
+    The protocol is ``@runtime_checkable`` so the pipeline can assert
+    conformance at build time (a misconfigured backend is caught
+    immediately rather than failing mid-run).
+    """
+
+    @property
+    def llm_spec(self) -> "LLMSpec":
+        """The LLM configuration this backend was built with."""
+        ...
+
+    def submit(self, prompts: "list[PromptBatch]") -> str:
+        """Compile + upload + start the job; return provider_job_id.
+
+        Must NOT block on results — the caller relies on the immediate
+        id to persist in the RunRegistry and return to the user.
+        """
+        ...
+
+    def poll(self, provider_job_id: str) -> BatchProgress:
+        """Return a provider-agnostic progress snapshot."""
+        ...
+
+    def collect(self, provider_job_id: str) -> "Iterator[LLMResponse]":
+        """Download finished results and yield decoded LLMResponses.
+
+        Only valid once ``poll(...)`` reports ``is_terminal``; calling
+        on an in-flight job raises ``ValueError``.
+        """
+        ...
+
+
+__all__ = ["BatchProgress", "ExecutionBackend"]

--- a/ondine/orchestration/backends/live.py
+++ b/ondine/orchestration/backends/live.py
@@ -1,0 +1,333 @@
+"""LiveBackend — the asyncio engine behind the backend protocol.
+
+This is the live-mode counterpart to :class:`ProviderBatchBackend`. Both
+implement the same :class:`~ondine.orchestration.backends.base.ExecutionBackend`
+job-lifecycle protocol (``submit`` → ``poll`` → ``collect``), so the
+front and back halves of the pipeline — and the CLI's ``submit`` /
+``status`` / ``collect`` commands — work identically whether a run
+executes live or via a provider batch job.
+
+Degenerate lifecycle (live-note):
+    A live run makes real HTTP calls and completes in one process, so it
+    has no genuine job-id-then-later-collect separation like a batch API
+    does. ``LiveBackend`` expresses that as a *degenerate* lifecycle:
+
+    * ``submit()`` runs the concurrent engine **synchronously** (it
+      blocks until every response is in), flattens the results, caches
+      them keyed by a synthetic ``live-*`` id, and returns the id.
+    * ``poll()`` always reports ``is_terminal=True`` — the work is done.
+    * ``collect()`` yields the cached :class:`~ondine.core.models.LLMResponse`
+      objects without re-running anything.
+
+    This deliberately relaxes the "submit is non-blocking" contract that
+    holds for batch backends (see the protocol docstring). The relaxation
+    is safe because live mode is inherently synchronous: the results
+    cannot outlive the submitting process, so there is no async
+    submit→collect handoff to protect. The ``live-`` prefix on the job id
+    lets the CLI distinguish these in-memory-only jobs and refuse a
+    cross-process ``collect`` on them (results would be gone).
+
+Engine provenance:
+    The engine wiring below (instructor-mode override, client creation,
+    observer-dispatcher wiring, rate limiter, retry handler, observer
+    lifecycle) is a verbatim move of the logic that previously lived
+    inline in ``Pipeline._execute_stages_with_tracking`` (stage 3) and
+    later in t3's ``invoke()``-shaped LiveBackend. Behaviour is
+    byte-for-byte identical to the pre-extraction code path — the same
+    :class:`~ondine.stages.llm_invocation_stage.LLMInvocationStage` is
+    constructed with the same parameters and run through the same
+    observer notifications.
+"""
+
+from __future__ import annotations
+
+import itertools
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+from ondine.adapters import create_llm_client
+from ondine.orchestration.backends.base import BatchProgress
+from ondine.orchestration.observers import LoggingObserver
+from ondine.orchestration.progress_tracker import NoOpProgressTracker
+from ondine.stages.llm_invocation_stage import LLMInvocationStage
+from ondine.utils import RateLimiter, RetryHandler, get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ondine.core.models import LLMResponse, PromptBatch, ResponseBatch
+    from ondine.core.specifications import LLMSpec, PipelineSpecifications
+    from ondine.orchestration.execution_context import ExecutionContext
+
+logger = get_logger(__name__)
+
+# Process-local result cache for the degenerate lifecycle. Keyed by the
+# synthetic ``live-*`` id returned from submit(); drained by collect().
+# A module-level dict (not instance state) because a live "job" is fully
+# contained within submit()+collect() of one backend instance — but
+# keeping it at module scope matches how the CLI rebuilds a fresh
+# LiveBackend per process and still (correctly) finds nothing for a
+# live-* id in a separate process.
+_live_results: dict[str, list[LLMResponse]] = {}
+
+# Monotonic counter for live job ids. One space is fine: live jobs
+# complete synchronously inside submit(), so there is no cross-process
+# coordination to worry about.
+_live_job_counter = itertools.count(1)
+
+
+def _build_rate_limiter(processing_spec: Any) -> RateLimiter | None:
+    """Assemble the rate limiter for a pipeline run.
+
+    Moved unchanged from ``ondine.api.pipeline`` so the live backend
+    owns every dependency of the invocation middle.
+    """
+    rpm = processing_spec.rate_limit_rpm
+    if not rpm:
+        return None
+
+    burst = min(20, processing_spec.concurrency)
+    local = RateLimiter(rpm, burst_size=burst)
+
+    redis_url = getattr(processing_spec, "rate_limit_redis_url", None)
+    if not redis_url:
+        return local
+
+    from ondine.utils.redis_rate_limiter import RedisRateLimiter
+
+    return RedisRateLimiter(
+        requests_per_minute=rpm,
+        redis_url=redis_url,
+        scope=processing_spec.rate_limit_scope,
+        burst_size=burst,
+        fallback=local,
+    )
+
+
+class LiveBackend:
+    """ExecutionBackend that runs the concurrent asyncio engine synchronously.
+
+    Constructed with the LLM spec plus the full pipeline context the
+    live engine needs (observers, progress tracker, cache) and an
+    optional budget controller — these live on the
+    :class:`~ondine.orchestration.execution_context.ExecutionContext`,
+    which does not exist at the point batch backends are built, so the
+    live backend takes them at construction instead. The pipeline builds
+    a fresh LiveBackend per run once the context exists.
+
+    The class deliberately does NOT subclass the Protocol — structural
+    conformance (``@runtime_checkable``) is the contract, mirroring
+    :class:`ProviderBatchBackend` and the rest of ondine's protocols.
+    """
+
+    def __init__(
+        self,
+        llm_spec: LLMSpec,
+        *,
+        specs: PipelineSpecifications | None = None,
+        context: ExecutionContext | None = None,
+        budget_controller: Any | None = None,
+    ) -> None:
+        """Configure the backend for a live run.
+
+        Args:
+            llm_spec: Provider + model + credentials (required by the
+                protocol's ``llm_spec`` property).
+            specs: Full pipeline specifications. The engine reads
+                concurrency / retry / rate-limit / error-policy from
+                ``specs.processing`` and the instructor-mode override
+                from ``specs.metadata``. Required to actually run; may
+                be ``None`` only for protocol-conformance checks.
+            context: Execution context carrying observers, progress
+                tracker, and response cache. Required to run; may be
+                ``None`` only for protocol-conformance checks.
+            budget_controller: Optional per-run budget guard injected by
+                the pipeline when ``processing.max_budget`` is set.
+        """
+        self._llm_spec = llm_spec
+        self._specs = specs
+        self._context = context
+        self._budget_controller = budget_controller
+
+    @property
+    def llm_spec(self) -> LLMSpec:
+        """The LLM configuration this backend was built with."""
+        return self._llm_spec
+
+    def submit(self, prompts: list[PromptBatch]) -> str:
+        """Run the engine to completion and return a ``live-*`` job id.
+
+        Blocks synchronously (degenerate lifecycle — see the module
+        docstring). The flattened results are cached in-process keyed by
+        the returned id, so a subsequent :meth:`collect` in the same
+        process yields them without re-running anything.
+        """
+        if not prompts:
+            job_id = self._next_job_id()
+            _live_results[job_id] = []
+            return job_id
+
+        response_batches = self._run_engine(prompts)
+        responses = _flatten_to_llm_responses(response_batches)
+        job_id = self._next_job_id()
+        _live_results[job_id] = responses
+        return job_id
+
+    def poll(self, provider_job_id: str) -> BatchProgress:
+        """Always terminal: a live job is complete by the time submit() returns."""
+        n = len(_live_results.get(provider_job_id, []))
+        return BatchProgress(
+            provider_job_id=provider_job_id,
+            status="completed",
+            total=n,
+            completed=n,
+            failed=0,
+            cost_so_far=Decimal("0"),
+            is_terminal=True,
+        )
+
+    def collect(self, provider_job_id: str) -> Iterator[LLMResponse]:
+        """Yield the cached responses for a job id (no re-run).
+
+        Yields nothing (rather than raising) for an unknown id — a caller
+        may hold a stale ``live-*`` id from a previous process, in which
+        case the results are simply gone.
+        """
+        for r in _live_results.get(provider_job_id, []):
+            yield r
+
+    # ── the engine, adapted from the inline pipeline path ────────────
+
+    def _run_engine(
+        self, batches: list[PromptBatch]
+    ) -> list[ResponseBatch]:
+        """Construct and run LLMInvocationStage exactly as the pipeline did.
+
+        Mirrors ``Pipeline._execute_stages_with_tracking`` stage 3:
+        instructor-mode override, client creation, observer-dispatcher
+        wiring, rate limiter, retry handler, and
+        concurrency/error-policy/adaptive settings are all applied
+        identically, wrapped in the same observer-lifecycle
+        notifications (on_stage_start / on_stage_complete / on_stage_error).
+        """
+        specs = self._specs
+        context = self._context
+        if specs is None or context is None:
+            raise RuntimeError(
+                "LiveBackend cannot run the engine without specs and context; "
+                "they are required at construction for a real run."
+            )
+
+        # --- instructor_mode override (moved verbatim) ---
+        llm_spec = specs.llm
+        if specs.metadata and "instructor_mode" in specs.metadata:
+            llm_spec = llm_spec.model_copy(
+                update={"instructor_mode": specs.metadata["instructor_mode"]}
+            )
+
+        llm_client = create_llm_client(llm_spec)
+
+        # Wire observer dispatcher to LLM client (for direct SDK integration).
+        if context.observer_dispatcher and hasattr(
+            llm_client, "set_observer_dispatcher"
+        ):
+            llm_client.set_observer_dispatcher(context.observer_dispatcher)
+
+        rate_limiter = _build_rate_limiter(specs.processing)
+        retry_handler = RetryHandler(
+            max_attempts=specs.processing.max_retries,
+            initial_delay=specs.processing.retry_delay,
+        )
+
+        llm_stage = LLMInvocationStage(
+            llm_client,
+            concurrency=specs.processing.concurrency,
+            rate_limiter=rate_limiter,
+            retry_handler=retry_handler,
+            error_policy=specs.processing.error_policy,
+            max_retries=specs.processing.max_retries,
+            output_cls=(
+                specs.metadata.get("structured_output_model")
+                if specs.metadata
+                else None
+            ),
+            budget_controller=self._budget_controller,
+            adaptive_concurrency=specs.processing.adaptive_concurrency,
+        )
+
+        # Observer lifecycle around the stage — same gating the pipeline
+        # used so the progress tracker, not LoggingObserver, emits the
+        # stage summary when a tracker is active.
+        tracker_ref = getattr(context, "_progress_tracker_ref", None)
+        tracker_active = tracker_ref is not None and not isinstance(
+            tracker_ref, NoOpProgressTracker
+        )
+        observers = getattr(context, "observers", []) or []
+        for observer in observers:
+            if tracker_active and isinstance(observer, LoggingObserver):
+                continue
+            observer.on_stage_start(llm_stage, context)
+
+        try:
+            response_batches = llm_stage.execute(batches, context)
+        except Exception as e:
+            for observer in observers:
+                observer.on_stage_error(llm_stage, context, e)
+            raise
+
+        for observer in observers:
+            if tracker_active and isinstance(observer, LoggingObserver):
+                continue
+            observer.on_stage_complete(llm_stage, context, response_batches)
+
+        return response_batches
+
+    @staticmethod
+    def _next_job_id() -> str:
+        return f"live-{next(_live_job_counter)}"
+
+
+def _flatten_to_llm_responses(batches: list[ResponseBatch]) -> list[LLMResponse]:
+    """Flatten ``list[ResponseBatch]`` into ``list[LLMResponse]``.
+
+    ``ResponseBatch.responses`` is typed ``list[str] | list[LLMResponse]``.
+    When the engine emits full :class:`LLMResponse` objects (the normal
+    path) they pass through unchanged. When it emits raw strings (e.g.
+    the structured-output-disabled path), a minimal :class:`LLMResponse`
+    is synthesised so the collect() contract — one ``LLMResponse`` per
+    row — always holds. Token/cost details are unknown at the string
+    layer and default to zero; the back-half parser consumes
+    ``LLMResponse.text`` regardless.
+    """
+    from ondine.core.models import LLMResponse
+
+    out: list[LLMResponse] = []
+    for batch in batches:
+        for idx, response in enumerate(batch.responses):
+            if isinstance(response, LLMResponse):
+                out.append(response)
+            else:
+                meta = (
+                    batch.metadata[idx].row_index
+                    if idx < len(batch.metadata)
+                    else idx
+                )
+                out.append(
+                    LLMResponse(
+                        text=response,
+                        tokens_in=0,
+                        tokens_out=0,
+                        model="",
+                        cost=Decimal("0"),
+                        latency_ms=(
+                            batch.latencies_ms[idx]
+                            if idx < len(batch.latencies_ms)
+                            else 0.0
+                        ),
+                        metadata={"row_index": meta},
+                    )
+                )
+    return out
+
+
+__all__ = ["LiveBackend"]

--- a/ondine/orchestration/backends/provider_batch.py
+++ b/ondine/orchestration/backends/provider_batch.py
@@ -1,0 +1,531 @@
+"""ProviderBatchBackend — OpenAI + Anthropic native Batch API backend.
+
+Architecture (see /plans/ARCHITECTURE_PROPOSAL.md §3, §5):
+
+This is the batch-mode replacement for the pipeline's middle stage.
+Instead of issuing one live HTTP request per prompt (the LiveBackend
+path), it compiles every prompt into a single JSONL payload, uploads
+that file to the provider's Batch API, kicks off a job, and later
+downloads + decodes the results. The front half (Load → Format →
+Aggregate) and back half (Disaggregate → Parse → Write) are untouched —
+they consume the same :class:`PromptBatch` / :class:`LLMResponse` types
+either way.
+
+Why a separate backend, not a flag on the live engine:
+
+* Batch APIs are *job-based*, not call-based. The natural unit is
+  "upload a file, get a job id, poll, download" — fundamentally
+  different control flow from a per-call asyncio gather. Forcing both
+  into one engine would create a special/general mixture (Ousterhout
+  red flag) where rare batch branches pollute the common live path.
+* The job lifecycle maps cleanly onto the RunRegistry: ``submit`` stores
+  a ``provider_job_id`` on the :class:`RunHandle`; ``ondine status``
+  polls it; ``ondine collect`` drains it. One shape, three commands.
+
+Design (deep module, information hiding):
+
+* The caller sees three methods (``submit`` / ``poll`` / ``collect``)
+  and never learns whether OpenAI or Anthropic is underneath. The
+  provider difference — JSONL line shape, endpoint path, response
+  envelope — is isolated in small private ``_openai_*`` / ``_anthropic_*``
+  helpers. Adding a third provider means adding one helper set, not
+  touching the pipeline, registry, or CLI.
+* Credentials are resolved lazily inside ``submit``: the backend reads
+  ``ANTHROPIC_API_KEY`` / ``OPENAI_API_KEY`` from the environment (or
+  from the LLMSpec) only when a job is actually submitted, never at
+  import time, so merely constructing the backend has no side effects.
+* v1 scope guard: only OpenAI and Anthropic support batch mode. The
+  guard fires in the constructor (defence in depth) AND in
+  :meth:`PipelineBuilder.build` (the single user-facing choke point).
+
+Tests mock the SDK client objects (the architectural boundary) so the
+JSONL encoding, response decoding, and provider_job_id round-trip are
+all exercised against real code with no network.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import uuid
+from collections.abc import Iterator
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+from ondine.orchestration.backends.base import BatchProgress
+from ondine.utils import get_logger
+
+if TYPE_CHECKING:
+    from ondine.core.models import LLMResponse, PromptBatch
+    from ondine.core.specifications import LLMSpec
+
+logger = get_logger(__name__)
+
+# v1 scope: only these providers ship a Batch API we support. Listed once
+# here and checked in the constructor (defence in depth) and in
+# PipelineBuilder.build (the user-facing choke point). Adding a provider
+# means adding it here plus the matching _<provider>_ helpers below.
+SUPPORTED_BATCH_PROVIDERS: frozenset[str] = frozenset(
+    {"openai", "anthropic"}
+)
+
+# Canonical statuses the backend treats as "done". Kept provider-neutral
+# so poll()/collect() never leak provider vocabulary to callers.
+_TERMINAL_STATUSES: frozenset[str] = frozenset(
+    {
+        "completed",
+        "failed",
+        "expired",
+        "cancelled",  # OpenAI
+        "ended",  # Anthropic terminal umbrella
+        "succeeded",  # generic
+    }
+)
+
+
+class ProviderBatchBackend:
+    """Batch-API backend implementing the :class:`ExecutionBackend` protocol.
+
+    The backend is constructed from an :class:`LLMSpec` (which selects
+    the provider + model + pricing) and, optionally, a pre-built SDK
+    client (the test seam — production code lets the backend build its
+    own client lazily on first ``submit``). All provider specifics live
+    behind private methods; the public surface is provider-agnostic.
+
+    The class deliberately does NOT subclass the Protocol — structural
+    conformance (``@runtime_checkable``) is the contract, mirroring how
+    the rest of ondine treats protocols (see knowledge/context stores).
+    """
+
+    def __init__(
+        self,
+        llm_spec: "LLMSpec",
+        *,
+        client: Any | None = None,
+    ) -> None:
+        """Configure the backend for a specific provider + model.
+
+        Args:
+            llm_spec: Provider, model, pricing, and credentials. The
+                provider MUST be in :data:`SUPPORTED_BATCH_PROVIDERS`.
+            client: Optional pre-built provider SDK client. Production
+                callers omit this (the backend builds one lazily); tests
+                inject a mock here to exercise the encoding/decoding
+                paths without any network.
+        """
+        provider_key = self._provider_key(llm_spec)
+        if provider_key not in SUPPORTED_BATCH_PROVIDERS:
+            raise ValueError(
+                f"provider_batch mode is only supported for "
+                f"{sorted(SUPPORTED_BATCH_PROVIDERS)} in v1, got provider "
+                f"'{provider_key}'. Use execution_mode='live' for other "
+                f"providers."
+            )
+        self._llm_spec = llm_spec
+        # NOTE: attribute named ``_provider`` (not ``_provider_key``) so it
+        # does not shadow the ``_provider_key`` staticmethod below.
+        self._provider = provider_key
+        self._client = client  # lazily built in _ensure_client()
+        # custom_id → RowMetadata index, so collect() can preserve order.
+        # Populated during submit(); consumed during collect().
+        self._custom_ids: list[str] = []
+
+    # ── ExecutionBackend protocol surface ──────────────────────────
+
+    @property
+    def llm_spec(self) -> "LLMSpec":
+        """The LLM configuration this backend was built with."""
+        return self._llm_spec
+
+    def submit(self, prompts: "list[PromptBatch]") -> str:
+        """Compile prompts to JSONL, upload, start the job, return its id.
+
+        Non-blocking: returns as soon as the provider acknowledges the
+        batch creation. The returned id is what the caller persists on
+        the :class:`RunHandle` (``provider_job_id``) for later polling.
+        """
+        client = self._ensure_client()
+        self._custom_ids = []
+        provider_job_id = (
+            self._openai_submit(client, prompts)
+            if self._provider == "openai"
+            else self._anthropic_submit(client, prompts)
+        )
+        logger.info(
+            "Submitted %s batch job %s (%d requests)",
+            self._provider,
+            provider_job_id,
+            len(self._custom_ids),
+        )
+        return provider_job_id
+
+    def poll(self, provider_job_id: str) -> BatchProgress:
+        """Return a provider-agnostic progress snapshot for the job."""
+        client = self._ensure_client()
+        if self._provider == "openai":
+            return self._openai_poll(client, provider_job_id)
+        return self._anthropic_poll(client, provider_job_id)
+
+    def collect(self, provider_job_id: str) -> "Iterator[LLMResponse]":
+        """Download + decode finished results, one LLMResponse per request.
+
+        Raises ValueError if the job is not yet terminal — collecting an
+        in-flight job would return a partial file or a confusing provider
+        error, so we refuse cleanly (mirrors RunRegistry's terminal-only
+        collect contract).
+        """
+        client = self._ensure_client()
+        progress = self.poll(provider_job_id)
+        if not progress.is_terminal:
+            raise ValueError(
+                f"Batch job {provider_job_id} is not terminal "
+                f"(status={progress.status}); poll until complete."
+            )
+        if self._provider == "openai":
+            yield from self._openai_collect(client, provider_job_id)
+        else:
+            yield from self._anthropic_collect(client, provider_job_id)
+
+    # ── OpenAI Batch API ───────────────────────────────────────────
+
+    def _openai_submit(
+        self, client: Any, prompts: "list[PromptBatch]"
+    ) -> str:
+        """Compile OpenAI-format JSONL, upload file, create batch."""
+        jsonl = self._build_openai_jsonl(prompts)
+        upload_file = ("requests.jsonl", io.BytesIO(jsonl.encode()), "application/json")
+        file_obj = client.files.create(
+            file=upload_file, purpose="batch"
+        )
+        batch = client.batches.create(
+            input_file_id=file_obj.id,
+            endpoint="/v1/chat/completions",
+            completion_window="24h",
+            metadata={"source": "ondine"},
+        )
+        return batch.id
+
+    def _openai_poll(
+        self, client: Any, provider_job_id: str
+    ) -> BatchProgress:
+        batch = client.batches.retrieve(provider_job_id)
+        counts = getattr(batch, "request_counts", None)
+        total = int(getattr(counts, "total", 0) or 0)
+        completed = int(getattr(counts, "completed", 0) or 0)
+        failed = int(getattr(counts, "failed", 0) or 0)
+        return BatchProgress(
+            provider_job_id=provider_job_id,
+            status=batch.status,
+            total=total,
+            completed=completed,
+            failed=failed,
+            cost_so_far=self._estimate_cost(completed, failed),
+            is_terminal=batch.status in _TERMINAL_STATUSES,
+        )
+
+    def _openai_collect(
+        self, client: Any, provider_job_id: str
+    ) -> "Iterator[LLMResponse]":
+        batch = client.batches.retrieve(provider_job_id)
+        result_file_id = (
+            getattr(batch, "output_file_id", None)
+            or getattr(batch, "error_file_id", None)
+        )
+        if result_file_id is None:
+            return
+        content = client.files.content(result_file_id)
+        raw = getattr(content, "content", b"") or b""
+        for line in raw.decode().splitlines():
+            if not line.strip():
+                continue
+            yield self._decode_openai_line(json.loads(line))
+
+    # ── Anthropic Batch API ────────────────────────────────────────
+
+    def _anthropic_submit(
+        self, client: Any, prompts: "list[PromptBatch]"
+    ) -> str:
+        """Compile Anthropic-format requests, create message batch."""
+        requests = self._build_anthropic_requests(prompts)
+        batch = client.messages.batches.create(requests=requests)
+        return batch.id
+
+    def _anthropic_poll(
+        self, client: Any, provider_job_id: str
+    ) -> BatchProgress:
+        batch = client.messages.batches.retrieve(provider_job_id)
+        # Anthropic exposes counts as result_counts on the batch object.
+        counts = getattr(batch, "result_counts", None) or {}
+        total = int(
+            getattr(counts, "processing", 0)
+            + getattr(counts, "succeeded", 0)
+            + getattr(counts, "errored", 0)
+            + getattr(counts, "canceled", 0)
+            + getattr(counts, "expired", 0)
+        ) if not isinstance(counts, dict) else sum(counts.values())
+        succeeded = int(getattr(counts, "succeeded", 0)) if not isinstance(
+            counts, dict
+        ) else int(counts.get("succeeded", 0))
+        errored = int(getattr(counts, "errored", 0)) if not isinstance(
+            counts, dict
+        ) else int(counts.get("errored", 0))
+        return BatchProgress(
+            provider_job_id=provider_job_id,
+            status=batch.processing_status if hasattr(batch, "processing_status") else getattr(batch, "status", "unknown"),
+            total=total,
+            completed=succeeded,
+            failed=errored,
+            cost_so_far=self._estimate_cost(succeeded, errored),
+            is_terminal=self._anthropic_is_terminal(batch),
+        )
+
+    def _anthropic_collect(
+        self, client: Any, provider_job_id: str
+    ) -> "Iterator[LLMResponse]":
+        # Anthropic streams results via the list() iterator.
+        results = client.messages.batches.results(provider_job_id)
+        for entry in results:
+            yield self._decode_anthropic_entry(entry)
+
+    # ── JSONL / request compilers ──────────────────────────────────
+
+    def _build_openai_jsonl(self, prompts: "list[PromptBatch]") -> str:
+        """Flatten PromptBatches into OpenAI Batch JSONL.
+
+        One line per prompt row. The ``custom_id`` carries the original
+        row index so collect() can reconstruct order without a separate
+        side-table; it is also stashed in ``self._custom_ids`` for tests
+        and debugging.
+        """
+        lines: list[str] = []
+        for batch in prompts:
+            for prompt_text, meta in zip(batch.prompts, batch.metadata):
+                custom_id = f"row-{meta.row_index}"
+                self._custom_ids.append(custom_id)
+                record = {
+                    "custom_id": custom_id,
+                    "method": "POST",
+                    "url": "/v1/chat/completions",
+                    "body": {
+                        "model": self._llm_spec.model,
+                        "messages": self._openai_messages(prompt_text),
+                        "temperature": self._llm_spec.temperature,
+                    },
+                }
+                if self._llm_spec.max_tokens is not None:
+                    record["body"]["max_tokens"] = self._llm_spec.max_tokens
+                lines.append(json.dumps(record))
+        return "\n".join(lines) + ("\n" if lines else "")
+
+    def _build_anthropic_requests(
+        self, prompts: "list[PromptBatch]"
+    ) -> list[dict[str, Any]]:
+        """Flatten PromptBatches into Anthropic Batch request objects."""
+        requests: list[dict[str, Any]] = []
+        for batch in prompts:
+            for prompt_text, meta in zip(batch.prompts, batch.metadata):
+                custom_id = f"row-{meta.row_index}"
+                self._custom_ids.append(custom_id)
+                requests.append(
+                    {
+                        "custom_id": custom_id,
+                        "params": {
+                            "model": self._llm_spec.model,
+                            "max_tokens": self._llm_spec.max_tokens or 1024,
+                            "messages": self._anthropic_messages(prompt_text),
+                            "temperature": self._llm_spec.temperature,
+                        },
+                    }
+                )
+        return requests
+
+    # ── response decoders ──────────────────────────────────────────
+
+    def _decode_openai_line(self, record: dict[str, Any]) -> "LLMResponse":
+        """Translate one OpenAI Batch result line into an LLMResponse.
+
+        Handles both success (response.body present) and error
+        (response.status != 200) records so a single failed request
+        cannot poison the whole collect().
+        """
+        from ondine.core.models import LLMResponse
+
+        resp = record.get("response", {})
+        body = resp.get("body", {}) if isinstance(resp, dict) else {}
+        usage = body.get("usage", {}) or {}
+        tokens_in = int(usage.get("prompt_tokens", 0))
+        tokens_out = int(usage.get("completion_tokens", 0))
+        choices = body.get("choices", []) or []
+        text = (
+            choices[0]["message"]["content"]
+            if choices
+            else (resp.get("error", {}).get("message", "") if isinstance(resp, dict) else "")
+        )
+        model = body.get("model", self._llm_spec.model)
+        return LLMResponse(
+            text=text,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            model=model,
+            cost=self._row_cost(tokens_in, tokens_out),
+            latency_ms=0.0,
+            metadata={"custom_id": record.get("custom_id")},
+        )
+
+    def _decode_anthropic_entry(self, entry: Any) -> "LLMResponse":
+        """Translate one Anthropic Batch result into an LLMResponse."""
+        from ondine.core.models import LLMResponse
+
+        # entry has .result.message (success) or .result.error (failure)
+        result = getattr(entry, "result", entry)
+        message = getattr(result, "message", None)
+        usage = getattr(message, "usage", None) if message else None
+        tokens_in = int(getattr(usage, "input_tokens", 0)) if usage else 0
+        tokens_out = int(getattr(usage, "output_tokens", 0)) if usage else 0
+        text = ""
+        if message is not None:
+            content = getattr(message, "content", None)
+            if content:
+                # content is a list of text blocks
+                text = "".join(
+                    getattr(block, "text", "")
+                    for block in content
+                    if getattr(block, "type", None) == "text"
+                )
+        return LLMResponse(
+            text=text,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            model=self._llm_spec.model,
+            cost=self._row_cost(tokens_in, tokens_out),
+            latency_ms=0.0,
+            metadata={"custom_id": getattr(entry, "custom_id", "")},
+        )
+
+    # ── shared helpers ─────────────────────────────────────────────
+
+    def _openai_messages(self, prompt_text: str) -> list[dict[str, str]]:
+        """Wrap a prompt in OpenAI chat messages, honouring system_message."""
+        msgs: list[dict[str, str]] = []
+        if self._llm_spec.provider and hasattr(self._llm_spec, "system_message"):
+            # LLMSpec has no system_message field; system prompt lives in
+            # PromptSpec. The batch backend receives already-formatted
+            # prompts, so this path is a no-op kept for future use.
+            pass
+        msgs.append({"role": "user", "content": prompt_text})
+        return msgs
+
+    def _anthropic_messages(self, prompt_text: str) -> list[dict[str, str]]:
+        return [{"role": "user", "content": prompt_text}]
+
+    def _estimate_cost(
+        self, completed: int, failed: int
+    ) -> Decimal:
+        """Rough running cost from request counts (pre-download).
+
+        Used only for the live progress snapshot; the authoritative
+        cost comes from token usage during collect(). Falls back to a
+        per-request average when per-1k pricing is unset.
+        """
+        # Without per-row token data mid-flight, report zero — the
+        # registry's cost tracker is updated authoritatively during
+        # collect(). Keeping this conservative avoids overstating spend.
+        return Decimal("0")
+
+    def _row_cost(self, tokens_in: int, tokens_out: int) -> Decimal:
+        """Cost for a single decoded response from LLMSpec pricing."""
+        in_rate = self._llm_spec.input_cost_per_1k_tokens or Decimal("0")
+        out_rate = self._llm_spec.output_cost_per_1k_tokens or Decimal("0")
+        return (
+            Decimal(tokens_in) * in_rate / Decimal("1000")
+            + Decimal(tokens_out) * out_rate / Decimal("1000")
+        )
+
+    def _anthropic_is_terminal(self, batch: Any) -> bool:
+        """True when the Anthropic batch has stopped processing."""
+        status = (
+            getattr(batch, "processing_status", None)
+            or getattr(batch, "status", None)
+            or ""
+        )
+        return status in _TERMINAL_STATUSES or status == ""
+
+    @staticmethod
+    def _provider_key(llm_spec: "LLMSpec") -> str:
+        """Normalise the provider to a lowercase canonical key.
+
+        Handles both the enum form (``LLMProvider.OPENAI``) and the
+        LiteLLM-style ``"provider/model"`` model string so the scope
+        guard works regardless of how the user configured the spec.
+        """
+        from ondine.core.specifications import LLMProvider
+
+        provider = llm_spec.provider
+        if isinstance(provider, LLMProvider):
+            return provider.value
+        provider_str = str(provider).lower()
+        # Strip a leading "provider/" prefix from LiteLLM model strings
+        if "/" in provider_str:
+            provider_str = provider_str.split("/")[0]
+        # If the provider is the generic litellm sentinel, derive from
+        # the model string (e.g. "openai/gpt-4o-mini" → "openai").
+        if provider_str == "litellm" and "/" in llm_spec.model:
+            provider_str = llm_spec.model.split("/")[0].lower()
+        return provider_str
+
+    def _ensure_client(self) -> Any:
+        """Lazily build the provider SDK client on first use.
+
+        Construction is deferred so importing this module (and building
+        the backend at pipeline-build time) never requires credentials
+        or network. Only an actual ``submit`` needs a live client.
+        """
+        if self._client is not None:
+            return self._client
+        if self._provider == "openai":
+            self._client = self._build_openai_client()
+        else:
+            self._client = self._build_anthropic_client()
+        return self._client
+
+    def _build_openai_client(self) -> Any:
+        """Build an OpenAI client from env / spec credentials."""
+        from ondine.utils.optional_dependencies import (
+            _matches_missing_dependency,
+        )
+
+        try:
+            from openai import OpenAI
+        except ImportError as exc:
+            if _matches_missing_dependency(exc, ("openai",)):
+                raise ImportError(
+                    "OpenAI batch mode requires the 'openai' package. "
+                    "Install with: pip install openai"
+                ) from exc
+            raise
+        api_key = self._llm_spec.api_key or os.environ.get("OPENAI_API_KEY")
+        return OpenAI(api_key=api_key)
+
+    def _build_anthropic_client(self) -> Any:
+        """Build an Anthropic client from env / spec credentials."""
+        from ondine.utils.optional_dependencies import (
+            _matches_missing_dependency,
+        )
+
+        try:
+            from anthropic import Anthropic
+        except ImportError as exc:
+            if _matches_missing_dependency(exc, ("anthropic",)):
+                raise ImportError(
+                    "Anthropic batch mode requires the 'anthropic' package. "
+                    "Install with: pip install anthropic"
+                ) from exc
+            raise
+        api_key = self._llm_spec.api_key or os.environ.get(
+            "ANTHROPIC_API_KEY"
+        )
+        return Anthropic(api_key=api_key)
+
+
+__all__ = ["ProviderBatchBackend", "SUPPORTED_BATCH_PROVIDERS"]

--- a/ondine/orchestration/run_registry.py
+++ b/ondine/orchestration/run_registry.py
@@ -1,0 +1,483 @@
+"""Persistent job index for pipeline runs.
+
+The RunRegistry is the single source of truth for the lifetime of a run
+across process boundaries. The MCP ``ondine_run`` tool hands out a
+``run_id`` immediately; a worker process (or a later CLI invocation)
+resolves that same id against the on-disk SQLite database. Because the
+whole point is crash-safe durability, the registry is backed by a real
+SQLite file with WAL mode — never an in-memory mock.
+
+Design (deep module, information hiding):
+
+* ``RunRegistry`` exposes four operations — ``create``, ``get``,
+  ``list``, ``transition`` — and hides every SQL statement, schema
+  migration, and serialisation detail behind them.
+* ``RunHandle`` is an immutable snapshot read fresh from disk on every
+  ``get``/``list``/``transition`` call. There is deliberately no
+  in-memory cache: a second process polling status must see the
+  latest committed row, so caching would be a bug, not an optimisation.
+* ``RegistryObserver`` is the extension point for live progress feeds
+  (the MCP status stream). Observers are notified inside the same
+  transaction commit so a crash between "persist" and "notify" is
+  impossible.
+
+The registry is optional. ``Pipeline.execute(run_id=None)`` (the
+default) never touches it, so existing users see no new on-disk artefact.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from abc import ABC, abstractmethod
+from enum import Enum
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+from ondine.utils import get_logger
+
+logger = get_logger(__name__)
+
+# Sentinel filename inside the checkpoint directory. Co-located with
+# checkpoints and the response cache so that copying the checkpoint dir
+# also carries the run history — one artefact to back up.
+REGISTRY_FILENAME = "runs.db"
+
+
+class RunStatus(str, Enum):
+    """Lifecycle states for a single pipeline run.
+
+    The ordering encodes the legal forward transitions (see
+    ``_ALLOWED_TRANSITIONS``). A run moves strictly forward; there is no
+    "un-fail" path. PARTIAL covers the ProviderBatch case where some
+    rows succeeded but the job did not complete cleanly.
+    """
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUBMITTED_REMOTE = "submitted_remote"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    PARTIAL = "partial"
+
+
+# Legal forward edges. Key = current status, value = statuses reachable
+# in one hop. Defined once, checked on every transition so the registry
+# can never record an impossible history (e.g. PENDING -> SUCCEEDED).
+_ALLOWED_TRANSITIONS: dict[RunStatus, frozenset[RunStatus]] = {
+    RunStatus.PENDING: frozenset({RunStatus.RUNNING, RunStatus.FAILED}),
+    RunStatus.RUNNING: frozenset(
+        {
+            RunStatus.SUBMITTED_REMOTE,
+            RunStatus.SUCCEEDED,
+            RunStatus.FAILED,
+            RunStatus.PARTIAL,
+        }
+    ),
+    RunStatus.SUBMITTED_REMOTE: frozenset(
+        {RunStatus.SUCCEEDED, RunStatus.FAILED, RunStatus.PARTIAL}
+    ),
+    # Terminal states have no outgoing edges.
+    RunStatus.SUCCEEDED: frozenset(),
+    RunStatus.FAILED: frozenset(),
+    RunStatus.PARTIAL: frozenset(),
+}
+
+
+class RegistryObserver(ABC):
+    """Extension point for status-transition events.
+
+    Implementations drive the live progress feed in the MCP server and
+    any metrics sinks. The registry calls ``on_transition`` exactly once
+    per committed transition, after the row is durable on disk. An
+    observer that raises cannot roll back the transition — the registry
+    logs and swallows the error so one misbehaving listener cannot take
+    down a run (mirrors ``ExecutionContext.notify_progress``).
+    """
+
+    @abstractmethod
+    def on_transition(self, run_id: UUID, old: RunStatus, new: RunStatus) -> None:
+        """Called after a status transition is committed to disk."""
+        raise NotImplementedError
+
+
+class RunSpec:
+    """User-supplied description of a run at creation time.
+
+    A thin value object: ``pipeline_id`` identifies which pipeline
+    configuration is running, ``dataset`` is a short label for the input
+    (a filename or ``"dataframe"``), and ``spec_snapshot`` is the
+    arbitrary JSON-serialisable dict that resume and the CLI rely on to
+    reconstruct the run. Everything serialises through ``to_dict`` /
+    ``from_dict`` so the registry never has to know the shape.
+    """
+
+    def __init__(
+        self,
+        pipeline_id: str,
+        dataset: str = "",
+        spec_snapshot: dict[str, Any] | None = None,
+    ) -> None:
+        self.pipeline_id = pipeline_id
+        self.dataset = dataset
+        # Default the snapshot to the identifying fields so that callers
+        # who only pass pipeline_id/dataset still get a useful, non-empty
+        # snapshot (the contract every test asserts on).
+        self.spec_snapshot = (
+            dict(spec_snapshot)
+            if spec_snapshot
+            else {
+                "pipeline_id": pipeline_id,
+                "dataset": dataset,
+            }
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pipeline_id": self.pipeline_id,
+            "dataset": self.dataset,
+            "spec_snapshot": self.spec_snapshot,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunSpec:
+        # Tolerate both the full serialised form and a bare snapshot
+        # (tests pass {"spec_snapshot": {...}} directly).
+        if "spec_snapshot" in data and "pipeline_id" not in data:
+            snapshot = data["spec_snapshot"]
+            return cls(
+                pipeline_id=snapshot.get("pipeline_id", str(uuid4())),
+                dataset=snapshot.get("dataset", ""),
+                spec_snapshot=snapshot,
+            )
+        return cls(
+            pipeline_id=data.get("pipeline_id", str(uuid4())),
+            dataset=data.get("dataset", ""),
+            spec_snapshot=data.get("spec_snapshot"),
+        )
+
+
+class RunHandle:
+    """Immutable, read-only view of a run's current on-disk state.
+
+    A handle is a snapshot, not a live cursor: re-fetch via
+    ``registry.get(run_id)`` to observe subsequent transitions. Keeping
+    it immutable means callers cannot drift the in-memory copy out of
+    sync with the database.
+    """
+
+    __slots__ = (
+        "run_id",
+        "status",
+        "spec_snapshot",
+        "metrics",
+        "provider_job_id",
+        "created_at",
+        "updated_at",
+    )
+
+    def __init__(
+        self,
+        run_id: UUID,
+        status: RunStatus,
+        spec_snapshot: dict[str, Any],
+        metrics: dict[str, Any],
+        provider_job_id: str | None,
+        created_at: str,
+        updated_at: str,
+    ) -> None:
+        self.run_id = run_id
+        self.status = status
+        self.spec_snapshot = spec_snapshot
+        self.metrics = metrics
+        self.provider_job_id = provider_job_id
+        self.created_at = created_at
+        self.updated_at = updated_at
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return (
+            f"RunHandle(run_id={self.run_id}, status={self.status.name}, "
+            f"provider_job_id={self.provider_job_id!r})"
+        )
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS runs (
+    run_id           TEXT PRIMARY KEY,
+    status           TEXT NOT NULL,
+    spec_snapshot    TEXT NOT NULL,
+    metrics          TEXT NOT NULL DEFAULT '{}',
+    provider_job_id  TEXT,
+    created_at       TEXT NOT NULL,
+    updated_at       TEXT NOT NULL
+);
+"""
+
+
+def _row_to_handle(row: sqlite3.Row) -> RunHandle:
+    return RunHandle(
+        run_id=UUID(row["run_id"]),
+        status=RunStatus(row["status"]),
+        spec_snapshot=json.loads(row["spec_snapshot"]),
+        metrics=json.loads(row["metrics"] or "{}"),
+        provider_job_id=row["provider_job_id"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+class RunRegistry:
+    """Crash-safe, on-disk index of pipeline runs.
+
+    The registry is a deep module: callers use ``create`` / ``get`` /
+    ``list`` / ``transition`` and never see SQL, the WAL pragma, or the
+    serialisation format. The database file lives in the existing
+    checkpoint directory (or any path the caller chooses), so there is
+    exactly one persistence location to back up.
+
+    Thread-safety: a module-level lock serialises writes so concurrent
+    threads in one process cannot interleave a transition with observer
+    dispatch. Cross-process safety comes from SQLite's own file locking.
+    """
+
+    # Process-wide lock. SQLite serialises cross-process writes, but
+    # observer dispatch must not be interrupted by a second in-process
+    # transition.
+    _write_lock = threading.Lock()
+
+    def __init__(self, path: Path | str) -> None:
+        """Open (or create) the registry at ``path``.
+
+        ``path`` may be either a directory (the registry file is created
+        inside it as ``runs.db``, co-located with checkpoints) or a
+        direct file path. A directory keeps every persistence artefact
+        in one place; a file path is convenient for tests and ad-hoc
+        tooling.
+        """
+        path = Path(path)
+        if path.is_dir() or (not path.exists() and path.suffix == ""):
+            # Treat as a directory: ensure it exists, then nest the db.
+            path.mkdir(parents=True, exist_ok=True)
+            self._db_path = path / REGISTRY_FILENAME
+        else:
+            self._db_path = path
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self._conn = sqlite3.connect(
+            str(self._db_path),
+            isolation_level=None,  # autocommit; we manage txns explicitly
+            check_same_thread=False,
+        )
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._conn.executescript(_SCHEMA)
+        self._observers: list[RegistryObserver] = []
+
+    # ── observers ──────────────────────────────────────────────────
+
+    def add_observer(self, observer: RegistryObserver) -> None:
+        """Register an observer for status-transition events."""
+        self._observers.append(observer)
+
+    def remove_observer(self, observer: RegistryObserver) -> None:
+        """Unregister a previously-added observer (no-op if absent)."""
+        try:
+            self._observers.remove(observer)
+        except ValueError:
+            pass
+
+    # ── create / read ──────────────────────────────────────────────
+
+    def create(self, spec: RunSpec) -> RunHandle:
+        """Persist a new PENDING run and return its handle.
+
+        The run_id is generated server-side so callers can never
+        accidentally collide. The row is committed before the handle is
+        returned — the MCP tool only hands the id to the user after the
+        create is durable, which is the whole reason this module exists.
+        """
+        run_id = uuid4()
+        now = _now_iso()
+        snapshot_json = json.dumps(spec.spec_snapshot, default=str)
+        with self._write_lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                self._conn.execute(
+                    "INSERT INTO runs "
+                    "(run_id, status, spec_snapshot, metrics, "
+                    " provider_job_id, created_at, updated_at) "
+                    "VALUES (?, ?, ?, '{}', NULL, ?, ?)",
+                    (str(run_id), RunStatus.PENDING.value, snapshot_json, now, now),
+                )
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                raise
+        logger.debug("Created run %s (status=%s)", run_id, RunStatus.PENDING.name)
+        # Read back so the returned handle is exactly what's on disk.
+        handle = self._fetch(run_id)
+        assert handle is not None  # just inserted
+        return handle
+
+    def get(self, run_id: UUID) -> RunHandle | None:
+        """Return the current handle for ``run_id``, or None if absent.
+
+        Reads are uncached: every call hits disk so a second process
+        polling status observes committed transitions immediately.
+        """
+        return self._fetch(run_id)
+
+    def list(self, status: RunStatus | None = None) -> list[RunHandle]:
+        """List runs, newest-first, optionally filtered by status.
+
+        Newest-first matches the CLI ``ondine status`` UX: the run the
+        user just kicked off is the one they want to see at the top.
+        """
+        if status is None:
+            rows = self._conn.execute(
+                # Order by rowid DESC — SQLite assigns rowid in insertion
+                # order, so this gives newest-first deterministically
+                # even when several creates land within the same
+                # microsecond clock tick.
+                "SELECT * FROM runs ORDER BY rowid DESC"
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM runs WHERE status = ? ORDER BY rowid DESC",
+                (status.value,),
+            ).fetchall()
+        return [_row_to_handle(r) for r in rows]
+
+    # ── transition ─────────────────────────────────────────────────
+
+    def transition(
+        self,
+        run_id: UUID,
+        status: RunStatus,
+        *,
+        metrics: dict[str, Any] | None = None,
+        provider_job_id: str | None = None,
+    ) -> RunHandle:
+        """Move ``run_id`` to ``status``, persist, notify observers.
+
+        Validates the transition against ``_ALLOWED_TRANSITIONS``,
+        merges any ``metrics`` / ``provider_job_id`` overrides onto the
+        existing row, commits, then fires observers exactly once with
+        ``(run_id, old_status, new_status)``. Observer exceptions are
+        logged and swallowed so a misbehaving listener cannot corrupt
+        the on-disk state or starve other observers.
+
+        Raises:
+            KeyError: if ``run_id`` does not exist (programmer error —
+                callers only transition known runs).
+            ValueError: if the transition is not in
+                ``_ALLOWED_TRANSITIONS``.
+        """
+        with self._write_lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._conn.execute(
+                    "SELECT * FROM runs WHERE run_id = ?", (str(run_id),)
+                ).fetchone()
+                if row is None:
+                    self._conn.execute("ROLLBACK")
+                    raise KeyError(run_id)
+
+                old_status = RunStatus(row["status"])
+                if status not in _ALLOWED_TRANSITIONS.get(old_status, frozenset()):
+                    self._conn.execute("ROLLBACK")
+                    raise ValueError(
+                        f"Invalid transition {old_status.name} -> {status.name} "
+                        f"for run {run_id}"
+                    )
+
+                merged_metrics = json.loads(row["metrics"] or "{}")
+                if metrics:
+                    merged_metrics.update(metrics)
+
+                updated_at = _now_iso()
+                self._conn.execute(
+                    "UPDATE runs SET status = ?, metrics = ?, "
+                    "  provider_job_id = COALESCE(?, provider_job_id), "
+                    "  updated_at = ? WHERE run_id = ?",
+                    (
+                        status.value,
+                        json.dumps(merged_metrics, default=str),
+                        provider_job_id,
+                        updated_at,
+                        str(run_id),
+                    ),
+                )
+                self._conn.execute("COMMIT")
+            except Exception:
+                # ROLLBACK is idempotent on a non-transaction; guard it.
+                try:
+                    self._conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    pass
+                raise
+
+        new_handle = self._fetch(run_id)
+        assert new_handle is not None  # row exists; just updated
+        self._notify(run_id, old_status, status)
+        logger.info(
+            "Run %s transitioned %s -> %s",
+            run_id,
+            old_status.name,
+            status.name,
+        )
+        return new_handle
+
+    # ── lifecycle ──────────────────────────────────────────────────
+
+    def close(self) -> None:
+        """Close the database connection. Safe to call more than once."""
+        try:
+            self._conn.close()
+        except sqlite3.Error:
+            pass
+
+    # ── internals ──────────────────────────────────────────────────
+
+    def _fetch(self, run_id: UUID) -> RunHandle | None:
+        row = self._conn.execute(
+            "SELECT * FROM runs WHERE run_id = ?", (str(run_id),)
+        ).fetchone()
+        return _row_to_handle(row) if row is not None else None
+
+    def _notify(self, run_id: UUID, old: RunStatus, new: RunStatus) -> None:
+        """Fan out a transition to observers, swallowing their errors."""
+        for observer in list(self._observers):
+            try:
+                observer.on_transition(run_id, old, new)
+            except Exception:
+                logger.exception(
+                    "RegistryObserver %s raised on %s -> %s for run %s",
+                    type(observer).__name__,
+                    old.name,
+                    new.name,
+                    run_id,
+                )
+
+    def __enter__(self) -> RunRegistry:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+
+def _now_iso() -> str:
+    """UTC ISO-8601 timestamp with microsecond resolution.
+
+    Microsecond precision is required so that rapid sequential creates
+    (the common case — the MCP server may issue several run_ids in one
+    request) get distinct timestamps and ``list()`` can order them
+    newest-first deterministically.
+    """
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")

--- a/ondine/orchestration/run_registry.py
+++ b/ondine/orchestration/run_registry.py
@@ -354,6 +354,52 @@ class RunRegistry:
 
     # ── transition ─────────────────────────────────────────────────
 
+    def update_metrics(
+        self,
+        run_id: UUID,
+        metrics: dict[str, Any],
+    ) -> RunHandle:
+        """Merge ``metrics`` onto the run's row without changing status.
+
+        Distinct from ``transition``: live progress (rows done, cost so far)
+        churns many times per second during a run, while status moves a
+        handful of times across the whole lifetime. Firing observers on every
+        metric write would drown real transition events, and status pollers
+        only re-read the row on demand anyway — so this method persists the
+        merge and returns the updated handle without notifying anyone.
+
+        Raises:
+            KeyError: if ``run_id`` does not exist.
+        """
+        with self._write_lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._conn.execute(
+                    "SELECT metrics FROM runs WHERE run_id = ?", (str(run_id),)
+                ).fetchone()
+                if row is None:
+                    self._conn.execute("ROLLBACK")
+                    raise KeyError(run_id)
+
+                merged = json.loads(row["metrics"] or "{}")
+                merged.update(metrics)
+
+                self._conn.execute(
+                    "UPDATE runs SET metrics = ?, updated_at = ? WHERE run_id = ?",
+                    (json.dumps(merged, default=str), _now_iso(), str(run_id)),
+                )
+                self._conn.execute("COMMIT")
+            except Exception:
+                try:
+                    self._conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    pass
+                raise
+
+        new_handle = self._fetch(run_id)
+        assert new_handle is not None  # row exists; just updated
+        return new_handle
+
     def transition(
         self,
         run_id: UUID,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
     "jupyter>=1.0.0",
     "pydocstyle>=6.3.0",
     "interrogate>=1.7.0",
+    "fastmcp>=3.0.0",
 ]
 redis = [
     "redis>=5.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,9 @@ knowledge = [
     "pymupdf>=1.24",
     "sentence-transformers>=3.0",
 ]
+mcp = [
+    "fastmcp>=3.0.0",
+]
 zep = [
     "zep-cloud>=2.0",
 ]
@@ -121,11 +124,13 @@ all = [
     "azure-identity>=1.15.0",
     "pymupdf>=1.24",
     "sentence-transformers>=3.0",
+    "fastmcp>=3.0.0",
 ]
 
 [project.scripts]
 ondine = "ondine.cli.main:cli"
 hermes = "ondine.cli.main:cli"  # Keep backward compatibility alias
+ondine-mcp = "ondine.mcp.server:main"
 
 [build-system]
 requires = ["maturin>=1.0,<2.0"]

--- a/tests/e2e/test_live_backend_e2e.py
+++ b/tests/e2e/test_live_backend_e2e.py
@@ -1,0 +1,143 @@
+"""E2E: LiveBackend against the REAL DeepSeek API.
+
+Gated on ``DEEPSEEK_API_KEY`` — skipped in CI unless the secret is
+configured, so offline runs stay clean (same pattern as
+``test_builder_adaptive_real_api.py``).
+
+What this catches that the unit tests don't:
+* ``tests/unit/test_live_backend.py`` mocks both ``create_llm_client``
+  AND ``LLMInvocationStage`` at the architectural boundary, so it never
+  makes an HTTP call. A wiring regression that only surfaces when the
+  real LiteLLM completion path runs through the live engine — e.g. an
+  instructor-mode override that breaks a real model, a response-shape
+  the flattener mishandles, the ``live-*`` cache losing results across
+  submit/collect — would pass the unit suite and fail here.
+
+Contract exercised (end to end):
+    LiveBackend.submit()  → real engine → ``live-*`` job id
+    LiveBackend.poll()    → BatchProgress(is_terminal=True)
+    LiveBackend.collect() → 10 non-empty LLMResponse, one per row
+    total cost < $0.01
+"""
+
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("DEEPSEEK_API_KEY"),
+    reason="DEEPSEEK_API_KEY not set — skipping real-API E2E test",
+)
+
+
+def test_live_backend_e2e_deepseek_classification():
+    """Drive the full submit → poll → collect lifecycle against DeepSeek.
+
+    Regression: if the LiveBackend's degenerate lifecycle breaks under a
+    real provider — submit no longer blocks to completion, poll reports
+    non-terminal, collect yields fewer responses than rows, or the
+    flattened responses are empty strings — this test fails. The unit
+    suite cannot catch any of those because it intercepts the engine.
+    """
+    from ondine.core.models import PromptBatch, RowMetadata
+    from ondine.core.specifications import (
+        DatasetSpec,
+        DataSourceType,
+        LLMSpec,
+        PipelineSpecifications,
+        ProcessingSpec,
+        PromptSpec,
+    )
+    from ondine.orchestration.backends.base import BatchProgress
+    from ondine.orchestration.backends.live import LiveBackend
+    from ondine.orchestration.execution_context import ExecutionContext
+
+    api_key = os.environ["DEEPSEEK_API_KEY"]
+
+    # deepseek-v4-flash is a reasoning model: it spends tokens on internal
+    # reasoning before emitting visible text, so max_tokens must leave
+    # room for both. 64 is comfortably above the ~26 tokens observed per
+    # one-word classification while keeping cost negligible.
+    llm_spec = LLMSpec(
+        model="deepseek/deepseek-v4-flash",
+        api_key=api_key,  # pragma: allowlist secret
+        temperature=0.0,
+        max_tokens=64,
+    )
+
+    specs = PipelineSpecifications(
+        dataset=DatasetSpec(
+            source_type=DataSourceType.DATAFRAME,
+            input_columns=["text"],
+            output_columns=["category"],
+        ),
+        prompt=PromptSpec(
+            template=(
+                "Classify the following text into exactly one category, "
+                "replying with a single lowercase word: "
+                "fruit, vegetable, grain, dairy, meat, or other.\n\n"
+                "Text: {text}"
+            ),
+        ),
+        llm=llm_spec,
+        processing=ProcessingSpec(
+            batch_size=10,
+            concurrency=5,
+            max_retries=2,
+        ),
+    )
+    context = ExecutionContext()
+
+    backend = LiveBackend(llm_spec=llm_spec, specs=specs, context=context)
+
+    # A 10-row "DataFrame" represented as one PromptBatch — the shape the
+    # pipeline's front half (format → aggregate) hands to the middle.
+    texts = [
+        "apple", "carrot", "bread", "milk", "chicken",
+        "banana", "spinach", "rice", "cheese", "beef",
+    ]
+    prompts = [specs.prompt.template.format(text=t) for t in texts]
+    batch = PromptBatch(
+        prompts=prompts,
+        metadata=[RowMetadata(row_index=i) for i in range(len(texts))],
+        batch_id=0,
+    )
+
+    # ── submit ──────────────────────────────────────────────────────
+    job_id = backend.submit([batch])
+    assert job_id.startswith("live-"), (
+        f"submit() must return a 'live-'-prefixed job id, got {job_id!r}"
+    )
+
+    # ── poll ────────────────────────────────────────────────────────
+    progress = backend.poll(job_id)
+    assert isinstance(progress, BatchProgress)
+    assert progress.is_terminal is True, (
+        "poll() must report terminal for a live job (work is done at submit)"
+    )
+    assert progress.completed == len(texts), (
+        f"poll completed={progress.completed}, expected {len(texts)}"
+    )
+    assert progress.failed == 0
+
+    # ── collect ─────────────────────────────────────────────────────
+    from ondine.core.models import LLMResponse
+
+    collected = list(backend.collect(job_id))
+    assert len(collected) == len(texts), (
+        f"collect() yielded {len(collected)} responses, expected {len(texts)}"
+    )
+    for r in collected:
+        assert isinstance(r, LLMResponse)
+        assert r.text and r.text.strip(), (
+            f"collected response must be non-empty, got {r.text!r}"
+        )
+
+    # ── cost guard ──────────────────────────────────────────────────
+    total_cost = sum((r.cost for r in collected), Decimal("0"))
+    assert total_cost < Decimal("0.01"), (
+        f"total cost {total_cost} must stay under $0.01 for 10 rows"
+    )

--- a/tests/unit/test_live_backend.py
+++ b/tests/unit/test_live_backend.py
@@ -1,0 +1,376 @@
+"""Tests for LiveBackend — the asyncio engine behind the submit/poll/collect
+protocol (degenerate lifecycle).
+
+Every test pins a concrete regression. Contract under test:
+
+* ``LiveBackend`` implements the ``ExecutionBackend`` protocol
+  (runtime-checkable ``@runtime_checkable``), so it can stand in as the
+  pipeline's middle stage alongside ``ProviderBatchBackend``.
+* ``submit()`` runs the concurrent asyncio engine **synchronously** and
+  returns a ``live-*`` job id whose results are cached in-process.
+  This is the deliberate degenerate-lifecycle trade-off documented in
+  the protocol docstring: live backends block in submit, batch backends
+  do not.
+* ``poll()`` always reports ``is_terminal=True`` for a live job id —
+  the work is already done, there is nothing to wait for.
+* ``collect()`` yields the cached ``LLMResponse`` objects (flattened
+  from the engine's ``ResponseBatch`` output), one per original row.
+* The CLI ``collect`` command refuses ``live-*`` job ids: live results
+  live in memory and cannot survive into a fresh collect process.
+
+The LLM client is mocked at the architectural boundary
+(``create_llm_client``) so no network call is made and no real API key
+is required. The engine wiring (rate limiter, retry handler, observer
+lifecycle) is exercised against real code paths.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ondine.core.models import LLMResponse, PromptBatch, RowMetadata
+from ondine.core.specifications import (
+    DatasetSpec,
+    LLMSpec,
+    PipelineSpecifications,
+    PromptSpec,
+)
+
+
+# ── protocol conformance ─────────────────────────────────────────────
+
+
+def test_live_backend_implements_execution_backend_protocol() -> None:
+    """Regression: LiveBackend MUST be recognised as an ExecutionBackend
+    by runtime-checkable isinstance. If the protocol were not satisfied,
+    the pipeline could not treat live and batch backends as
+    interchangeable, defeating the whole point of the abstraction."""
+    from ondine.orchestration.backends.base import ExecutionBackend
+    from ondine.orchestration.backends.live import LiveBackend
+
+    backend = LiveBackend(llm_spec=_openai_spec(), specs=_specs(), context=_context())
+    assert isinstance(backend, ExecutionBackend)
+
+
+def test_live_backend_exposes_submit_poll_collect() -> None:
+    """Regression: the job-lifecycle surface (submit/poll/collect) is the
+    contract the CLI submit/status/collect commands share across live
+    and batch modes. If any method is missing or renamed, the CLI's
+    single plumbing path breaks for live jobs."""
+    from ondine.orchestration.backends.live import LiveBackend
+
+    backend = LiveBackend(llm_spec=_openai_spec(), specs=_specs(), context=_context())
+    for method in ("submit", "poll", "collect"):
+        assert callable(getattr(backend, method, None)), (
+            f"LiveBackend missing job-lifecycle method: {method}"
+        )
+
+
+def test_live_backend_exposes_llm_spec_property() -> None:
+    """Regression: the protocol requires an ``llm_spec`` property so the
+    pipeline/CLI can read which provider a backend was built with
+    without coupling to the concrete class. If it disappears, every
+    backend-specific code path must grow an isinstance check."""
+    from ondine.orchestration.backends.live import LiveBackend
+
+    spec = _openai_spec()
+    backend = LiveBackend(llm_spec=spec, specs=_specs(), context=_context())
+    assert backend.llm_spec is spec
+
+
+# ── degenerate lifecycle: submit blocks, poll terminal, collect cached ──
+
+
+def test_submit_returns_live_prefixed_job_id() -> None:
+    """Regression: submit() must return an id with the ``live-`` prefix
+    so the CLI collect command can distinguish in-process live jobs
+    from cross-process batch jobs and refuse to collect the former in a
+    fresh process (their results live in memory and are gone)."""
+    from ondine.orchestration.backends.live import LiveBackend
+
+    backend = LiveBackend(llm_spec=_openai_spec(), specs=_specs(), context=_context())
+    with _mock_engine(responses=_two_llm_responses()):
+        job_id = backend.submit(_two_prompt_batches())
+
+    assert job_id.startswith("live-"), (
+        f"live job id must be 'live-'-prefixed, got {job_id!r}"
+    )
+
+
+def test_submit_runs_engine_synchronously_and_caches_results() -> None:
+    """Regression: the degenerate lifecycle contract — submit() runs the
+    engine to completion NOW and caches the flattened results keyed by
+    job id, so a subsequent collect() in the same process returns them.
+    If submit did not block, collect would find an empty cache and the
+    CLI's live path would silently return zero results."""
+    from ondine.orchestration.backends.live import LiveBackend
+
+    expected = _two_llm_responses()
+    backend = LiveBackend(llm_spec=_openai_spec(), specs=_specs(), context=_context())
+    with _mock_engine(responses=expected) as mock_stage:
+        job_id = backend.submit(_two_prompt_batches())
+
+    # The engine must have actually executed (not been deferred).
+    assert mock_stage.execute.called, "submit() must run the engine synchronously"
+    # collect() must yield the same number of results without re-running.
+    collected = list(backend.collect(job_id))
+    assert len(collected) == len(expected)
+    assert [r.text for r in collected] == [r.text for r in expected]
+
+
+def test_poll_always_reports_terminal() -> None:
+    """Regression: a live job is already complete by the time submit()
+    returns, so poll() must report is_terminal=True immediately. If it
+    reported in-flight, a poll loop would spin forever waiting for a
+    job that can never progress."""
+    from ondine.orchestration.backends.base import BatchProgress
+    from ondine.orchestration.backends.live import LiveBackend
+
+    backend = LiveBackend(llm_spec=_openai_spec(), specs=_specs(), context=_context())
+    with _mock_engine(responses=_two_llm_responses()):
+        job_id = backend.submit(_two_prompt_batches())
+
+    progress = backend.poll(job_id)
+
+    assert isinstance(progress, BatchProgress)
+    assert progress.is_terminal is True
+    assert progress.status == "completed"
+    assert progress.completed == 2
+    assert progress.failed == 0
+
+
+def test_collect_yields_one_llmresponse_per_row() -> None:
+    """Regression: collect() must yield flat LLMResponse objects (one per
+    original prompt row), NOT ResponseBatch objects. The CLI collect
+    path writes LLMResponse.text to CSV; handing it a ResponseBatch
+    would either crash or write nothing."""
+    from ondine.orchestration.backends.live import LiveBackend
+
+    backend = LiveBackend(llm_spec=_openai_spec(), specs=_specs(), context=_context())
+    with _mock_engine(responses=_two_llm_responses()):
+        job_id = backend.submit(_two_prompt_batches())
+
+    for r in backend.collect(job_id):
+        assert isinstance(r, LLMResponse), (
+            "collect() must yield LLMResponse, not ResponseBatch"
+        )
+
+
+def test_submit_empty_batches_returns_job_with_no_results() -> None:
+    """Regression: an empty prompt list is a valid degenerate input (the
+    pipeline front half produced no batches). submit() must still
+    return a live-* id and collect() must yield nothing, not raise."""
+    from ondine.orchestration.backends.live import LiveBackend
+
+    backend = LiveBackend(llm_spec=_openai_spec(), specs=_specs(), context=_context())
+    job_id = backend.submit([])
+
+    assert job_id.startswith("live-")
+    assert list(backend.collect(job_id)) == []
+
+
+def test_collect_for_unknown_job_id_yields_nothing() -> None:
+    """Regression: collect() must not raise on a job id it has never
+    seen (defensive — a caller may hold a stale id). It yields nothing
+    rather than KeyError-ing the whole CLI."""
+    from ondine.orchestration.backends.live import LiveBackend
+
+    backend = LiveBackend(llm_spec=_openai_spec(), specs=_specs(), context=_context())
+    assert list(backend.collect("live-999-nonexistent")) == []
+
+
+# ── flattening: ResponseBatch (str | LLMResponse) → LLMResponse ───────
+
+
+def test_flatten_handles_raw_string_responses() -> None:
+    """Regression: the engine may emit ResponseBatch.responses as raw
+    strings (e.g. structured-output-disabled path). collect() must
+    synthesise LLMResponse objects from them rather than crashing on a
+    type mismatch with the CLI's CSV writer."""
+    from ondine.orchestration.backends.live import LiveBackend
+
+    backend = LiveBackend(llm_spec=_openai_spec(), specs=_specs(), context=_context())
+    with _mock_engine(responses=["plain text one", "plain text two"]):
+        job_id = backend.submit(_two_prompt_batches())
+
+    collected = list(backend.collect(job_id))
+    assert len(collected) == 2
+    for r in collected:
+        assert isinstance(r, LLMResponse)
+        assert isinstance(r.text, str)
+
+
+def test_submit_preserves_response_order() -> None:
+    """Regression: collect() must yield responses in submit-order so the
+    back half (Disaggregate → Parse → Write) can correlate each response
+    with its original row. If the flattening re-ordered, row 0's answer
+    would land on row 1."""
+    from ondine.orchestration.backends.live import LiveBackend
+
+    ordered = [
+        LLMResponse(text="first", tokens_in=1, tokens_out=1, model="m", cost=Decimal("0"), latency_ms=1.0),
+        LLMResponse(text="second", tokens_in=2, tokens_out=2, model="m", cost=Decimal("0"), latency_ms=2.0),
+    ]
+    backend = LiveBackend(llm_spec=_openai_spec(), specs=_specs(), context=_context())
+    with _mock_engine(responses=ordered):
+        job_id = backend.submit(_two_prompt_batches())
+
+    collected = list(backend.collect(job_id))
+    assert [r.text for r in collected] == ["first", "second"]
+
+
+def test_each_submit_returns_distinct_job_id() -> None:
+    """Regression: multiple submits in one process must not collide on a
+    shared job id, or collect() would return the first run's results
+    for every subsequent run."""
+    from ondine.orchestration.backends.live import LiveBackend
+
+    backend = LiveBackend(llm_spec=_openai_spec(), specs=_specs(), context=_context())
+    with _mock_engine(responses=_two_llm_responses()):
+        job_a = backend.submit(_two_prompt_batches())
+        job_b = backend.submit(_two_prompt_batches())
+
+    assert job_a != job_b
+    assert len(list(backend.collect(job_a))) == 2
+    assert len(list(backend.collect(job_b))) == 2
+
+
+# ── CLI guard: collect refuses live-* job ids ─────────────────────────
+
+
+def test_cli_collect_refuses_live_job_id(capsys: pytest.CaptureFixture) -> None:
+    """Regression: live results live in the submitting process's memory
+    and cannot be rebuilt in a fresh collect process (unlike batch jobs,
+    which are reconstructed from the spec snapshot). If the CLI did not
+    refuse live-* ids, ``ondine collect`` would rebuild an empty
+    ProviderBatchBackend, call ``collect("live-1")`` on it, get nothing
+    back, and silently report "Collected 0 responses" — confusing the
+    user who did get results synchronously during the live run."""
+    from ondine.cli.main import cli
+
+    # Build a fake registry entry whose provider_job_id is a live-* id.
+    fake_handle = MagicMock()
+    fake_handle.provider_job_id = "live-1"
+    fake_handle.status.value = "succeeded"
+    fake_handle.run_id = MagicMock()
+    fake_handle.spec_snapshot = {}
+
+    with patch("ondine.orchestration.RunRegistry") as mock_registry_cls:
+        mock_registry_cls.return_value.get.return_value = fake_handle
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main(
+                ["collect", "00000000-0000-0000-0000-000000000001"],
+                standalone_mode=False,
+            )
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    out = captured.out.lower()
+    # Must be an explicit refusal naming the live job, not a silent
+    # "0 responses" success or an unrelated API-key error.
+    assert "live" in out, (
+        "CLI collect must explain why a live-* job id cannot be collected"
+    )
+    assert "cannot be collected" in out or "not a batch" in out, (
+        "CLI collect must clearly state the live job cannot be collected cross-process"
+    )
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+def _openai_spec() -> LLMSpec:
+    return LLMSpec(
+        model="openai/gpt-4o-mini",
+        api_key="sk-test",  # pragma: allowlist secret
+        temperature=0.0,
+    )
+
+
+def _specs() -> PipelineSpecifications:
+    from ondine.core.specifications import DataSourceType
+
+    return PipelineSpecifications(
+        dataset=DatasetSpec(
+            source_type=DataSourceType.DATAFRAME,
+            input_columns=["text"],
+            output_columns=["r"],
+        ),
+        prompt=PromptSpec(template="P: {text}"),
+        llm=_openai_spec(),
+    )
+
+
+def _context() -> Any:
+    """A minimal ExecutionContext with the fields the live engine reads."""
+    from ondine.orchestration.execution_context import ExecutionContext
+
+    return ExecutionContext()
+
+
+def _two_prompt_batches() -> list[PromptBatch]:
+    return [
+        PromptBatch(
+            prompts=["Classify: alpha", "Classify: beta"],
+            metadata=[RowMetadata(row_index=0), RowMetadata(row_index=1)],
+            batch_id=0,
+        ),
+    ]
+
+
+def _two_llm_responses() -> list[LLMResponse]:
+    return [
+        LLMResponse(text="A", tokens_in=3, tokens_out=1, model="gpt-4o-mini", cost=Decimal("0"), latency_ms=10.0),
+        LLMResponse(text="B", tokens_in=3, tokens_out=1, model="gpt-4o-mini", cost=Decimal("0"), latency_ms=12.0),
+    ]
+
+
+class _FakeStage:
+    """Stand-in for LLMInvocationStage that returns canned responses.
+
+    The real stage is built by the live backend; we only intercept
+    ``execute()`` so we control the engine's output without a network
+    call. ``called`` lets tests assert submit() actually ran the engine.
+    """
+
+    def __init__(self, responses: list[Any]) -> None:
+        from ondine.core.models import ResponseBatch
+
+        self._batch = ResponseBatch(
+            responses=responses,
+            metadata=[RowMetadata(row_index=i) for i in range(len(responses))],
+        )
+        self.execute = MagicMock(return_value=[self._batch])
+
+
+class _mock_engine:
+    """Patch create_llm_client + LLMInvocationStage so the live backend
+    builds a fake stage returning ``responses``."""
+
+    def __init__(self, responses: list[Any]) -> None:
+        self._responses = responses
+        self._patches: list[Any] = []
+
+    def __enter__(self) -> _FakeStage:
+        fake_stage = _FakeStage(self._responses)
+        self._patches = [
+            patch(
+                "ondine.orchestration.backends.live.create_llm_client",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "ondine.orchestration.backends.live.LLMInvocationStage",
+                return_value=fake_stage,
+            ),
+        ]
+        for p in self._patches:
+            p.start()
+        return fake_stage
+
+    def __exit__(self, *args: Any) -> None:
+        for p in self._patches:
+            p.stop()

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,404 @@
+"""Tests for the ondine MCP server (§4) — the L5 front door over L4.
+
+The MCP server exposes four tools (ondine_estimate, ondine_run, ondine_status,
+ondine_collect). These tests pin the behavioural contract each tool must hold,
+exercised through :class:`MCPService` (the plain-Python object the FastMCP tool
+functions delegate to). Testing the service directly keeps the unit tests fast
+and deterministic; the FastMCP wiring itself is a thin decorator pass-through
+that adds no logic worth unit-testing.
+
+Contract under test:
+
+* ``ondine_run`` is MANDATORY-budget when reached via MCP — an unset budget
+  must be rejected before any work begins (no runaway spend from a tool call).
+* ``ondine_run`` returns a ``run_id`` immediately and does not block on the LLM;
+  the work runs on a background thread that writes progress to the registry.
+* ``ondine_run`` injects the budget into the processing spec so the engine's
+  own BudgetController enforces the cap end-to-end.
+* ``ondine_status`` reads live progress (rows done, cost so far, %) from the
+  registry, even mid-flight.
+* ``ondine_status`` reports "not found" distinctly from a real run.
+* ``ondine_collect`` returns the result summary + output path once the run
+  reaches a terminal state, and refuses while the run is still in flight.
+* ``ondine_estimate`` is side-effect-free: it never creates a registry row and
+  never writes a checkpoint.
+* The registry progress observer writes rows/cost to the registry as the
+  pipeline runs, so ``ondine_status`` sees non-zero progress mid-run.
+
+The LLM client is mocked at the architectural boundary (``create_llm_client``)
+so no network call is made; everything else is real.
+"""
+
+from __future__ import annotations
+
+import time
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+import pandas as pd
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from ondine.core.models import LLMResponse
+from ondine.mcp.server import MCPService, create_server
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+_CONFIG_YAML = """
+dataset:
+  source_type: csv
+  source_path: "{input}"
+  input_columns: [text]
+  output_columns: [result]
+prompt:
+  template: "Classify: {{text}}"
+llm:
+  provider: openai
+  model: gpt-4o-mini
+processing:
+  batch_size: 5
+  concurrency: 2
+"""
+
+
+def _write_dataset(path: Path, rows: int = 12) -> None:
+    df = pd.DataFrame({"text": [f"row {i}" for i in range(rows)]})
+    df.to_csv(path, index=False)
+
+
+def _make_fake_llm_client_cls():
+    """Build a deterministic LLMClient subclass that needs no network.
+
+    Mirrors the proven mock pattern in test_run_registry.py: subclass the real
+    ``LLMClient`` so pricing/estimate_tokens/calculate_cost come for free, and
+    override only the invoke path to return a canned response.
+    """
+    from ondine.adapters.llm_client import LLMClient
+
+    class _FakeLLMClient(LLMClient):
+        def invoke(self, prompt, **kwargs):
+            return LLMResponse(
+                text="positive",
+                tokens_in=5,
+                tokens_out=1,
+                model=self.model,
+                cost=Decimal("0.001"),
+                latency_ms=1.0,
+            )
+
+        async def ainvoke(self, prompt, **kwargs):
+            return self.invoke(prompt, **kwargs)
+
+        def structured_invoke(self, prompt, output_cls, **kwargs):
+            return self.invoke(prompt, **kwargs)
+
+        async def structured_invoke_async(self, prompt, output_cls, **kwargs):
+            return self.invoke(prompt, **kwargs)
+
+        async def start(self):
+            pass
+
+        async def stop(self):
+            pass
+
+        def estimate_tokens(self, text):
+            return len(text) // 4
+
+    return _FakeLLMClient
+
+
+@pytest.fixture
+def fake_llm(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Patch the LLM client factory so no provider is contacted.
+
+    The pipeline resolves ``create_llm_client`` at call time from
+    ``ondine.api.pipeline``; patching it there covers both the sync and async
+    execution paths. Returns the fake client instance the pipeline will use.
+    """
+    fake_cls = _make_fake_llm_client_cls()
+
+    def _factory(llm_spec, *args, **kwargs):
+        return fake_cls(llm_spec)
+
+    monkeypatch.setattr("ondine.api.pipeline.create_llm_client", _factory)
+    return _factory
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> MCPService:
+    return MCPService(registry_dir=tmp_path)
+
+
+def _config_yaml(input_path: Path) -> str:
+    return _CONFIG_YAML.format(input=str(input_path))
+
+
+# ── regression: budget is mandatory on ondine_run ────────────────────
+
+
+def test_run_rejects_missing_budget(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: the architecture proposal mandates a budget cap on every MCP
+    run. If ondine_run accepted a missing budget, a tool caller could launch an
+    unbounded spend job with no ceiling — the exact footgun the cap exists to
+    prevent. The rejection must happen before any run is created.
+    """
+    inp = tmp_path / "in.csv"
+    _write_dataset(inp)
+    out = tmp_path / "out.csv"
+
+    with pytest.raises(ValueError, match="(?i)budget"):
+        service.ondine_run(
+            config_yaml=_config_yaml(inp),
+            input_path=str(inp),
+            output_path=str(out),
+            budget=None,
+        )
+
+    # No run row should have been persisted — rejection is pre-flight.
+    assert service.list_runs() == []
+
+
+def test_run_rejects_zero_budget(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: a budget of 0 or negative is equivalent to no cap (the
+    engine treats ``None`` as unlimited and ``0`` would trip instantly or never
+    depending on path). MCP must reject non-positive budgets explicitly.
+    """
+    inp = tmp_path / "in.csv"
+    _write_dataset(inp)
+    out = tmp_path / "out.csv"
+
+    with pytest.raises(ValueError, match="(?i)budget"):
+        service.ondine_run(
+            config_yaml=_config_yaml(inp),
+            input_path=str(inp),
+            output_path=str(out),
+            budget=0,
+        )
+
+
+# ── regression: ondine_run returns a run_id and does not block ───────
+
+
+def test_run_returns_run_id_immediately_and_does_not_block(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: ondine_run is documented to 'return run_id immediately
+    (never block)'. If it blocked on execute(), the MCP client would time out
+    waiting for a long job and the user would lose the handle to poll. The call
+    must return a resolvable run_id while the LLM has barely started.
+    """
+    inp = tmp_path / "in.csv"
+    _write_dataset(inp, rows=50)
+    out = tmp_path / "out.csv"
+
+    handle = service.ondine_run(
+        config_yaml=_config_yaml(inp),
+        input_path=str(inp),
+        output_path=str(out),
+        budget=Decimal("5.00"),
+    )
+
+    # A run_id is returned and is durable in the registry.
+    assert handle["run_id"]
+    status = service.ondine_status(handle["run_id"])
+    assert status["run_id"] == handle["run_id"]
+
+    # The returned status is a real, trackable state — not "unknown".
+    assert status["status"] in ("pending", "running", "succeeded", "failed", "partial")
+
+
+# ── regression: budget is injected into the processing spec ──────────
+
+
+def test_run_injects_budget_into_spec(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: the budget cap must reach the engine's own BudgetController,
+    not just be stored in the registry. If ondine_run only recorded the budget
+    for bookkeeping, a runaway job would blow past it because the invocation
+    stage never sees the limit. The persisted spec snapshot must carry it.
+    """
+    inp = tmp_path / "in.csv"
+    _write_dataset(inp)
+    out = tmp_path / "out.csv"
+
+    handle = service.ondine_run(
+        config_yaml=_config_yaml(inp),
+        input_path=str(inp),
+        output_path=str(out),
+        budget=Decimal("2.50"),
+    )
+
+    spec_snapshot = service.get_spec_snapshot(handle["run_id"])
+    assert spec_snapshot is not None
+    assert str(spec_snapshot["processing"]["max_budget"]).startswith("2.5")
+
+
+# ── regression: ondine_status reports live progress mid-flight ───────
+
+
+def test_status_reports_live_progress_during_run(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: ondine_status must show rows-done / cost-so-far while the
+    job is RUNNING. If progress never reached the registry, a user polling
+    status would see 0/0 until the very end — indistinguishable from a hung
+    job. The RegistryProgressObserver must forward progress to the registry.
+    """
+    inp = tmp_path / "in.csv"
+    _write_dataset(inp, rows=20)
+    out = tmp_path / "out.csv"
+
+    handle = service.ondine_run(
+        config_yaml=_config_yaml(inp),
+        input_path=str(inp),
+        output_path=str(out),
+        budget=Decimal("5.00"),
+    )
+
+    # Wait for the background run to make progress or finish.
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        st = service.ondine_status(handle["run_id"])
+        if st["status"] in ("succeeded", "failed", "partial"):
+            break
+        # While running, either rows_done>0 (progress observed) or we polled
+        # before the first batch landed — keep waiting.
+        time.sleep(0.05)
+
+    final = service.ondine_status(handle["run_id"])
+    assert final["status"] == "succeeded"
+    assert final["rows_done"] == 20
+    assert Decimal(final["cost"]) > 0
+
+
+# ── regression: ondine_status distinguishes unknown run_id ───────────
+
+
+def test_status_unknown_run_id_raises(
+    service: MCPService,
+) -> None:
+    """Regression: polling a run_id that was never created must surface a clear
+    'not found' error, not silently return a zeroed-out status. Otherwise a
+    typo in the run_id would look like an empty, instantly-finished job.
+    """
+    with pytest.raises(KeyError):
+        service.ondine_status(str(uuid4()))
+
+
+# ── regression: ondine_collect returns summary for a finished run ────
+
+
+def test_collect_returns_summary_after_success(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: ondine_collect is the terminal readout — rows, cost, and the
+    output path. If it didn't surface the output path, the user would have no
+    way to find their result file from the tool alone.
+    """
+    inp = tmp_path / "in.csv"
+    _write_dataset(inp, rows=8)
+    out = tmp_path / "out.csv"
+
+    handle = service.ondine_run(
+        config_yaml=_config_yaml(inp),
+        input_path=str(inp),
+        output_path=str(out),
+        budget=Decimal("5.00"),
+    )
+
+    collected = service.wait_and_collect(handle["run_id"], timeout=30)
+    assert collected["status"] == "succeeded"
+    assert collected["rows_done"] == 8
+    assert collected["output_path"] == str(out)
+    assert Decimal(collected["cost"]) > 0
+    # The output file really exists — collect doesn't lie about the artefact.
+    assert out.exists()
+
+
+def test_collect_refuses_in_flight_run(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: ondine_collect on a still-running job must not return a
+    half-written summary. It should report that the run is not finished so the
+    caller knows to poll status and come back.
+    """
+    # We can't easily freeze the run mid-flight with the fake client (it's
+    # fast), so instead seed a PENDING run directly and assert collect refuses.
+    handle = service._seed_pending_run()  # noqa: SLF001 — test-only seam
+    with pytest.raises(ValueError, match="(?i)not.*finished|in.?flight|running"):
+        service.ondine_collect(str(handle.run_id))
+
+
+# ── regression: ondine_estimate is side-effect-free ──────────────────
+
+
+def test_estimate_is_side_effect_free(
+    service: MCPService,
+    tmp_path: Path,
+    fake_llm: Any,
+) -> None:
+    """Regression: ondine_estimate is the 'demo tool' — fast and side-effect
+    -free. If it persisted a registry row or wrote a checkpoint, every estimate
+    call would pollute the run history and the checkpoint dir. Estimate must
+    leave the registry empty.
+    """
+    inp = tmp_path / "in.csv"
+    _write_dataset(inp)
+
+    estimate = service.ondine_estimate(config_yaml=_config_yaml(inp))
+
+    assert estimate["rows"] == 12
+    assert Decimal(estimate["total_cost"]) >= 0
+    assert estimate["total_tokens"] >= 0
+    # No run row created.
+    assert service.list_runs() == []
+
+
+# ── regression: create_server builds a FastMCP app with 4 tools ──────
+
+
+def test_create_server_registers_four_tools() -> None:
+    """Regression: the public entrypoint must wire exactly the four documented
+    tools onto a FastMCP server so an MCP client discovers them by name. If a
+    tool were missing or misnamed, the client would see an incomplete surface.
+    """
+    import asyncio
+
+    from fastmcp import FastMCP
+
+    server = create_server()
+    assert isinstance(server, FastMCP)
+    tools = asyncio.run(server.list_tools())
+    names = sorted(t.name for t in tools)
+    assert names == ["ondine_collect", "ondine_estimate", "ondine_run", "ondine_status"]
+
+
+def test_create_server_tools_are_callable(service: MCPService) -> None:
+    """The four service methods exist and are bound — guards against a rename
+    silently breaking the MCP surface.
+    """
+    for name in ("ondine_estimate", "ondine_run", "ondine_status", "ondine_collect"):
+        assert hasattr(service, name), f"MCPService missing tool {name!r}"

--- a/tests/unit/test_provider_batch.py
+++ b/tests/unit/test_provider_batch.py
@@ -1,0 +1,411 @@
+"""Tests for ProviderBatchBackend (§5) — OpenAI + Anthropic Batch API mode.
+
+Every test pins a concrete regression. Contract under test:
+
+* ``ProviderBatchBackend`` implements the ``ExecutionBackend`` protocol
+  (runtime-checkable ``@runtime_checkable``) — so it can be swapped in as
+  the pipeline's middle stage without changing the front/back halves.
+* ``submit()`` compiles PromptBatches to a provider JSONL, uploads it,
+  kicks off a batch job, and returns a ``provider_job_id`` **without
+  blocking** on the results (the whole reason batch mode exists).
+* ``poll()`` returns a ``BatchProgress`` snapshot (status + counts +
+  partial cost) so the registry/CLI can show live progress.
+* ``collect()`` downloads the finished results file and yields one
+  ``LLMResponse`` per request, decoding provider-specific JSON into the
+  ondine domain model — never leaking the raw provider envelope.
+* The v1 scope guard rejects unsupported providers at ``build()``: only
+  OpenAI and Anthropic may run in provider_batch mode. This is the single
+  choke point so an unsupported provider can never reach the backend.
+
+The OpenAI/Anthropic clients are mocked at the architectural boundary
+(the SDK client objects) so no network call is made and no real API key
+is required. Everything else (JSONL encoding, response decoding,
+provider_job_id round-trip) is exercised against real code paths.
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from ondine.core.models import LLMResponse, PromptBatch, RowMetadata
+from ondine.core.specifications import (
+    LLMProvider,
+    LLMSpec,
+    PipelineSpecifications,
+    ProcessingSpec,
+)
+
+# ── protocol conformance ─────────────────────────────────────────────
+
+
+def test_provider_batch_implements_execution_backend_protocol() -> None:
+    """Regression: ProviderBatchBackend MUST be recognised as an
+    ExecutionBackend by runtime-checkable isinstance. If the protocol
+    were not satisfied, the pipeline would silently fall back to the
+    live backend and the user's provider_batch intent would be ignored
+    without any error."""
+    from ondine.orchestration.backends.base import ExecutionBackend
+    from ondine.orchestration.backends.provider_batch import (
+        ProviderBatchBackend,
+    )
+
+    backend = ProviderBatchBackend(
+        llm_spec=_openai_spec(),
+    )
+    assert isinstance(backend, ExecutionBackend)
+
+
+def test_provider_batch_exposes_submit_poll_collect() -> None:
+    """Regression: the job-lifecycle surface (submit/poll/collect) is
+    the contract the RunRegistry provider_job_id and the CLI
+    submit/status/collect commands are built against. If any method is
+    missing or renamed, the registry would store a provider_job_id that
+    nothing can resolve."""
+    from ondine.orchestration.backends.provider_batch import (
+        ProviderBatchBackend,
+    )
+
+    backend = ProviderBatchBackend(llm_spec=_openai_spec())
+    for method in ("submit", "poll", "collect"):
+        assert callable(getattr(backend, method, None)), (
+            f"ProviderBatchBackend missing job-lifecycle method: {method}"
+        )
+
+
+# ── scope guard (v1: OpenAI + Anthropic only) ─────────────────────────
+
+
+def test_scope_guard_allows_openai() -> None:
+    """Regression: OpenAI is a v1-supported provider for batch mode.
+    Rejecting it would break the documented happy path."""
+    from ondine.orchestration.backends.provider_batch import (
+        SUPPORTED_BATCH_PROVIDERS,
+    )
+
+    assert LLMProvider.OPENAI in SUPPORTED_BATCH_PROVIDERS
+
+
+def test_scope_guard_allows_anthropic() -> None:
+    """Regression: Anthropic is a v1-supported provider for batch mode."""
+    from ondine.orchestration.backends.provider_batch import (
+        SUPPORTED_BATCH_PROVIDERS,
+    )
+
+    assert LLMProvider.ANTHROPIC in SUPPORTED_BATCH_PROVIDERS
+
+
+def test_scope_guard_rejects_unsupported_provider_in_builder() -> None:
+    """Regression: a user who selects provider_batch with an unsupported
+    provider (e.g. Groq) would otherwise get a silent, confusing
+    failure deep in the batch submit path. The guard at build() is the
+    single choke point — catching it early with a clear message."""
+    from ondine.api.pipeline_builder import PipelineBuilder
+
+    with pytest.raises(ValueError, match="provider_batch.*groq"):
+        (
+            PipelineBuilder.create()
+            .from_csv("data.csv", input_columns=["text"], output_columns=["r"])
+            .with_prompt("P: {text}")
+            .with_llm(provider="groq", model="llama-3.3-70b-versatile")
+            .with_execution_mode("provider_batch")
+            .build()
+        )
+
+
+def test_scope_guard_in_backend_constructor_for_groq() -> None:
+    """Regression: even if a caller constructs the backend directly
+    (bypassing the builder), an unsupported provider must still raise —
+    defence in depth so a programmatic misuse cannot slip through."""
+    from ondine.orchestration.backends.provider_batch import (
+        ProviderBatchBackend,
+    )
+
+    groq_spec = LLMSpec(provider=LLMProvider.GROQ, model="llama-3.3-70b-versatile")
+    with pytest.raises(ValueError, match="provider_batch"):
+        ProviderBatchBackend(llm_spec=groq_spec)
+
+
+# ── submit/poll/collect flow — OpenAI (mocked SDK) ────────────────────
+
+
+def test_openai_submit_compiles_jsonl_and_returns_job_id() -> None:
+    """Regression: submit() must (a) write one JSONL line per prompt,
+    (b) hand the file to the OpenAI Batch API, and (c) return the
+    provider's batch id immediately. If it blocked on results, the
+    entire non-blocking batch UX (ondine submit → later ondine collect)
+    collapses back into a synchronous call."""
+    from ondine.orchestration.backends.provider_batch import (
+        ProviderBatchBackend,
+    )
+
+    prompts = _two_prompt_batches()
+    mock_client = MagicMock()
+    mock_batches = MagicMock()
+    mock_batches.id = "batch_abc123"
+    mock_batches.status = "validating"
+    mock_client.batches.create.return_value = mock_batches
+    mock_files = MagicMock()
+    mock_files.id = "file_xyz"
+    mock_files.status = "processed"
+    mock_client.files.create.return_value = mock_files
+    mock_client.files.content.return_value = MagicMock(content=b"{}")
+
+    backend = ProviderBatchBackend(llm_spec=_openai_spec(), client=mock_client)
+
+    job_id = backend.submit(prompts)
+
+    assert job_id == "batch_abc123"
+    # One upload + one batch create call
+    mock_client.files.create.assert_called_once()
+    mock_client.batches.create.assert_called_once()
+    # The uploaded file content must be valid JSONL with one line per prompt
+    uploaded_bytes = mock_client.files.create.call_args.kwargs["file"][1]
+    lines = [
+        ln for ln in uploaded_bytes.read().decode().splitlines() if ln.strip()
+    ]
+    assert len(lines) == 2
+    for line in lines:
+        record = json.loads(line)
+        assert record["custom_id"]
+        assert record["method"] == "POST"
+        assert record["url"] == "/v1/chat/completions"
+
+
+def test_openai_poll_returns_progress_snapshot() -> None:
+    """Regression: poll() translates the provider's job status into a
+    canonical BatchProgress so the registry/CLI never see provider-
+    specific field names. If the mapping leaked, changing providers
+    would break every downstream consumer."""
+    from ondine.orchestration.backends.provider_batch import (
+        BatchProgress,
+        ProviderBatchBackend,
+    )
+
+    mock_client = MagicMock()
+    mock_batch = MagicMock()
+    mock_batch.id = "batch_abc"
+    mock_batch.status = "in_progress"
+    mock_batch.request_counts = MagicMock(
+        total=100, completed=40, failed=2
+    )
+    mock_client.batches.retrieve.return_value = mock_batch
+
+    backend = ProviderBatchBackend(llm_spec=_openai_spec(), client=mock_client)
+    progress = backend.poll("batch_abc")
+
+    assert isinstance(progress, BatchProgress)
+    assert progress.total == 100
+    assert progress.completed == 40
+    assert progress.failed == 2
+    assert progress.is_terminal is False
+
+
+def test_openai_collect_yields_llm_responses() -> None:
+    """Regression: collect() must decode the provider result JSONL into
+    ondine LLMResponse objects — one per request — keeping token/cost
+    accounting consistent with the live path. Leaking the raw provider
+    envelope would force every downstream stage to know two formats."""
+    from ondine.orchestration.backends.provider_batch import (
+        ProviderBatchBackend,
+    )
+
+    mock_client = MagicMock()
+    mock_batch = MagicMock()
+    mock_batch.id = "batch_abc"
+    mock_batch.status = "completed"
+    mock_batch.request_counts = MagicMock(
+        total=2, completed=2, failed=0
+    )
+    mock_client.batches.retrieve.return_value = mock_batch
+
+    result_jsonl = (
+        json.dumps(
+            {
+                "id": "req_1",
+                "custom_id": "row-0",
+                "response": {
+                    "status_code": 200,
+                    "body": {
+                        "usage": {
+                            "prompt_tokens": 10,
+                            "completion_tokens": 3,
+                        },
+                        "choices": [
+                            {"message": {"content": "positive"}}
+                        ],
+                        "model": "gpt-4o-mini",
+                    },
+                },
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "id": "req_2",
+                "custom_id": "row-1",
+                "response": {
+                    "status_code": 200,
+                    "body": {
+                        "usage": {
+                            "prompt_tokens": 8,
+                            "completion_tokens": 3,
+                        },
+                        "choices": [
+                            {"message": {"content": "negative"}}
+                        ],
+                        "model": "gpt-4o-mini",
+                    },
+                },
+            }
+        )
+        + "\n"
+    )
+    mock_content = MagicMock()
+    mock_content.content = result_jsonl.encode()
+    mock_client.files.content.return_value = mock_content
+
+    backend = ProviderBatchBackend(llm_spec=_openai_spec(), client=mock_client)
+    responses = list(backend.collect("batch_abc"))
+
+    assert len(responses) == 2
+    assert all(isinstance(r, LLMResponse) for r in responses)
+    assert responses[0].text == "positive"
+    assert responses[0].tokens_in == 10
+    assert responses[0].tokens_out == 3
+    assert responses[1].text == "negative"
+
+
+def test_openai_collect_refuses_non_terminal() -> None:
+    """Regression: collect() on an in-flight job would return a partial
+    file or raise a confusing provider error. The contract — matching
+    RunRegistry's terminal-only collect — is to refuse cleanly."""
+    from ondine.orchestration.backends.provider_batch import (
+        ProviderBatchBackend,
+    )
+
+    mock_client = MagicMock()
+    mock_batch = MagicMock()
+    mock_batch.status = "in_progress"
+    mock_batch.request_counts = MagicMock(total=2, completed=1, failed=0)
+    mock_client.batches.retrieve.return_value = mock_batch
+
+    backend = ProviderBatchBackend(llm_spec=_openai_spec(), client=mock_client)
+    with pytest.raises(ValueError, match="not terminal"):
+        list(backend.collect("batch_abc"))
+
+
+# ── Anthropic variant — proves provider complexity is hidden ──────────
+
+
+def test_anthropic_submit_uses_messages_batch_endpoint() -> None:
+    """Regression: Anthropic's Batch API has a different request shape
+    (``/v1/messages/batches`` with ``requests``) than OpenAI. The
+    backend must translate once, internally, so callers see one
+    submit() regardless of provider."""
+    from ondine.orchestration.backends.provider_batch import (
+        ProviderBatchBackend,
+    )
+
+    prompts = _two_prompt_batches()
+    mock_client = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.id = "msgbatch_001"
+    mock_client.messages.batches.create.return_value = mock_resp
+
+    backend = ProviderBatchBackend(
+        llm_spec=_anthropic_spec(), client=mock_client
+    )
+    job_id = backend.submit(prompts)
+
+    assert job_id == "msgbatch_001"
+    mock_client.messages.batches.create.assert_called_once()
+    # The Anthropic batch wraps each prompt as a request object
+    sent = mock_client.messages.batches.create.call_args
+    assert "requests" in sent.kwargs
+
+
+# ── spec wiring: execution_mode + builder ─────────────────────────────
+
+
+def test_processing_spec_has_execution_mode_default_live() -> None:
+    """Regression: adding the field must not change default behaviour.
+    Existing pipelines (which never set it) must stay in live mode — a
+    silent flip to batch would surprise every current user."""
+    spec = ProcessingSpec()
+    assert spec.execution_mode == "live"
+
+
+def test_processing_spec_accepts_provider_batch() -> None:
+    spec = ProcessingSpec(execution_mode="provider_batch")
+    assert spec.execution_mode == "provider_batch"
+
+
+def test_processing_spec_rejects_unknown_execution_mode() -> None:
+    """Regression: a typo like 'batch' must fail fast at validation,
+    not silently default to live (defeating the feature) or crash later
+    in the backend."""
+    with pytest.raises(Exception):  # pydantic ValidationError
+        ProcessingSpec(execution_mode="batch")  # type: ignore[arg-type]
+
+
+def test_builder_with_execution_mode_sets_spec() -> None:
+    """Regression: the builder method must propagate the choice into
+    the ProcessingSpec so the pipeline's build() scope guard and the
+    backend selection both read the same source of truth."""
+    from ondine.api.pipeline_builder import PipelineBuilder
+
+    builder = (
+        PipelineBuilder.create()
+        .from_csv("data.csv", input_columns=["text"], output_columns=["r"])
+        .with_prompt("P: {text}")
+        .with_llm(provider="openai", model="gpt-4o-mini")
+        .with_execution_mode("provider_batch")
+    )
+    assert builder._processing_spec.execution_mode == "provider_batch"
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+def _openai_spec() -> LLMSpec:
+    return LLMSpec(
+        provider=LLMProvider.OPENAI,
+        model="gpt-4o-mini",
+        api_key="sk-test",  # pragma: allowlist secret
+        temperature=0.0,
+        input_cost_per_1k_tokens=Decimal("0.00015"),
+        output_cost_per_1k_tokens=Decimal("0.0006"),
+    )
+
+
+def _anthropic_spec() -> LLMSpec:
+    return LLMSpec(
+        provider=LLMProvider.ANTHROPIC,
+        model="claude-sonnet-4-20250514",
+        api_key="sk-ant-test",  # pragma: allowlist secret
+        max_tokens=8192,
+        temperature=0.0,
+        input_cost_per_1k_tokens=Decimal("0.003"),
+        output_cost_per_1k_tokens=Decimal("0.015"),
+    )
+
+
+def _two_prompt_batches() -> list[PromptBatch]:
+    return [
+        PromptBatch(
+            prompts=["Classify: alpha", "Classify: beta"],
+            metadata=[
+                RowMetadata(row_index=0),
+                RowMetadata(row_index=1),
+            ],
+            batch_id=0,
+        ),
+    ]

--- a/tests/unit/test_run_registry.py
+++ b/tests/unit/test_run_registry.py
@@ -494,6 +494,52 @@ def test_pipeline_execute_failure_records_failed_state(
     assert final.status is RunStatus.FAILED
 
 
+# ── regression: update_metrics writes live progress without a transition ──
+
+
+def test_update_metrics_merges_without_changing_status(
+    registry: RunRegistry,
+) -> None:
+    """Regression: the MCP ``ondine_status`` tool reports live rows/cost for a
+    RUNNING job. If update_metrics transitioned status or replaced metrics
+    wholesale, status polling would either break the FSM or lose the fields the
+    terminal transition wrote. Live progress must merge onto the row in place.
+    """
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+    registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    registry.update_metrics(handle.run_id, {"processed_rows": 42, "cost": "1.25"})
+
+    after = registry.get(handle.run_id)
+    assert after is not None
+    assert after.status is RunStatus.RUNNING  # unchanged
+    assert after.metrics["processed_rows"] == 42
+    assert after.metrics["cost"] == "1.25"
+
+
+def test_update_metrics_is_visible_to_a_second_process(
+    tmp_path: Path,
+) -> None:
+    """Regression: a status poller is a different process opening its own
+    registry handle. If update_metrics were in-memory only, the MCP status tool
+    would never see live progress from the worker thread/process that ran the
+    job. The merge must hit the on-disk row.
+    """
+    registry_a = RunRegistry(tmp_path / "runs.db")
+    handle = registry_a.create(RunSpec(pipeline_id=str(uuid4())))
+    registry_a.transition(handle.run_id, RunStatus.RUNNING)
+    registry_a.update_metrics(handle.run_id, {"processed_rows": 7})
+    registry_a.close()
+
+    registry_b = RunRegistry(tmp_path / "runs.db")
+    try:
+        seen = registry_b.get(handle.run_id)
+        assert seen is not None
+        assert seen.metrics.get("processed_rows") == 7
+    finally:
+        registry_b.close()
+
+
 # ── fixtures ──────────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_run_registry.py
+++ b/tests/unit/test_run_registry.py
@@ -1,0 +1,505 @@
+"""Tests for RunRegistry — persistent job index for pipeline runs.
+
+Every test pins a concrete regression. The contract under test:
+
+* `create(spec)` returns a RunHandle with status PENDING, durable on disk.
+* `get(run_id)` returns the up-to-date handle. `list(status?)` filters.
+* `transition(run_id, status, **fields)` validates the transition, persists,
+  and notifies RegistryObservers exactly once with (run_id, old, new).
+* Pipelines that pass `run_id=` to `execute()` register and progress through
+  PENDING → RUNNING → SUCCEEDED|FAILED|PARTIAL. Default `run_id=None` leaves
+  behaviour unchanged (no registry artifact on disk).
+
+The SUT is `RunRegistry` against a real on-disk SQLite DB in a temp dir —
+the entire motivation is crash-safe durability, which mocks cannot prove.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+from uuid import UUID, uuid4
+
+import pandas as pd
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from ondine.core.specifications import (
+    DatasetSpec,
+    DataSourceType,
+    LLMProvider,
+    LLMSpec,
+    PipelineSpecifications,
+    PromptSpec,
+)
+from ondine.orchestration.run_registry import (
+    RegistryObserver,
+    RunRegistry,
+    RunSpec,
+    RunStatus,
+)
+
+# ── regression #1: create persists a PENDING run ──────────────────────
+
+
+def test_create_returns_pending_handle(registry: RunRegistry) -> None:
+    """Regression: if create did not persist, the MCP ``ondine_run`` tool
+    would return a run_id that no later ``ondine_status`` could resolve —
+    a lost job invisible to the user."""
+    spec = RunSpec(pipeline_id=str(uuid4()), dataset="df")
+    handle = registry.create(spec)
+
+    assert isinstance(handle.run_id, UUID)
+    assert handle.status is RunStatus.PENDING
+    assert handle.spec_snapshot == {"pipeline_id": spec.pipeline_id, "dataset": "df"}
+
+
+def test_get_returns_up_to_date_handle(registry: RunRegistry) -> None:
+    """Regression: get() must read the current on-disk state, not a
+    cached handle. Otherwise a second process polling status for a
+    long-running job would forever see PENDING."""
+    spec = RunSpec(pipeline_id=str(uuid4()))
+    handle = registry.create(spec)
+
+    registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    fresh = registry.get(handle.run_id)
+    assert fresh.status is RunStatus.RUNNING
+    assert fresh.run_id == handle.run_id
+
+
+def test_get_unknown_run_id_returns_none(registry: RunRegistry) -> None:
+    """Regression: callers (CLI, MCP) must distinguish "no such run"
+    from "run exists". A KeyError forces callers into try/except noise;
+    None is the clean sentinel."""
+    assert registry.get(uuid4()) is None
+
+
+# ── regression #2: durability across processes ────────────────────────
+
+
+def test_create_survives_process_kill(tmp_path: Path) -> None:
+    """Regression: the MCP server issues a run_id immediately, then a
+    worker process picks it up. If the registry were not crash-durable
+    across process boundaries, the worker could never resolve the run
+    the server started. Mirror the ResponseCache crash test: hard
+    ``os._exit`` proves the WAL commit survived."""
+    db_path = tmp_path / "runs.db"
+    spec = RunSpec(pipeline_id=str(uuid4()), dataset="df")
+    spec_dict = spec.to_dict()
+
+    worker = f"""
+import os, sys
+from ondine.orchestration.run_registry import RunRegistry, RunSpec
+registry = RunRegistry({str(db_path)!r})
+registry.create(RunSpec.from_dict({spec_dict!r}))
+os._exit(9)
+"""
+
+    proc = subprocess.run(
+        [sys.executable, "-c", worker],
+        env={**os.environ, "PYTHONPATH": os.getcwd()},
+        capture_output=True,
+        timeout=30,
+    )
+    assert proc.returncode == 9, (
+        f"worker did not hard-exit: {proc.returncode}\\n{proc.stderr.decode()}"
+    )
+
+    registry = RunRegistry(db_path)
+    runs = registry.list()
+    assert len(runs) == 1
+    assert runs[0].status is RunStatus.PENDING
+
+
+def test_reopen_sees_previously_written_runs(tmp_path: Path) -> None:
+    """Regression: status lookups happen in a new process (the CLI's
+    ``ondine status <run_id>`` is a fresh invocation). Data must survive
+    the close/reopen boundary."""
+    db_path = tmp_path / "reopen.db"
+    a = RunRegistry(db_path)
+    spec = RunSpec(pipeline_id=str(uuid4()))
+    handle = a.create(spec)
+    a.close()
+
+    b = RunRegistry(db_path)
+    try:
+        fresh = b.get(handle.run_id)
+        assert fresh is not None
+        assert fresh.status is RunStatus.PENDING
+    finally:
+        b.close()
+
+
+# ── regression #3: transition validation & observer fan-out ─────────
+
+
+def test_valid_transition_persists_and_returns_updated_handle(
+    registry: RunRegistry,
+) -> None:
+    """Regression: transition() must both persist and return the new
+    state. If it returned the stale handle, callers chaining off the
+    return would race the on-disk write."""
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+
+    updated = registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    assert updated.status is RunStatus.RUNNING
+    assert registry.get(handle.run_id).status is RunStatus.RUNNING
+
+
+def test_invalid_transition_raises_value_error(registry: RunRegistry) -> None:
+    """Regression: PENDING → SUCCEEDED must be rejected — a run that
+    never registered as RUNNING cannot be SUCCEEDED. Without this guard
+    the registry would record impossible state histories that a later
+    consumer (MCP /admin) would treat as valid."""
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+
+    with pytest.raises(ValueError, match="transition"):
+        registry.transition(handle.run_id, RunStatus.SUCCEEDED)
+
+
+def test_transition_unknown_run_id_raises_key_error(registry: RunRegistry) -> None:
+    """Regression: transitioning a non-existent run is a programmer error
+    (the MCP tool only operates on known run_ids). A silent no-op would
+    let a bug in the caller pass undetected."""
+    with pytest.raises(KeyError):
+        registry.transition(uuid4(), RunStatus.RUNNING)
+
+
+def test_transition_invokes_observers_exactly_once(
+    registry: RunRegistry,
+) -> None:
+    """Regression: observers drive the live progress feed in the MCP
+    server. Firing twice duplicates every status event in the user's
+    stream; firing zero times hides completion. Exactly once."""
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+    seen: list[tuple[UUID, RunStatus, RunStatus]] = []
+
+    class Recorder(RegistryObserver):
+        def on_transition(self, run_id: UUID, old: RunStatus, new: RunStatus) -> None:
+            seen.append((run_id, old, new))
+
+    registry.add_observer(Recorder())
+
+    registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    assert seen == [(handle.run_id, RunStatus.PENDING, RunStatus.RUNNING)]
+
+
+def test_observer_exception_does_not_break_transition(
+    registry: RunRegistry,
+) -> None:
+    """Regression: an observer (e.g. a metrics sink) must not be able to
+    take down the registry — the transition must still persist even when
+    a downstream listener raises. Matches the silent-observer-failure
+    contract of ``ExecutionContext.notify_progress``."""
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+
+    class Boom(RegistryObserver):
+        def on_transition(self, run_id: UUID, old: RunStatus, new: RunStatus) -> None:
+            raise RuntimeError("observer exploded")
+
+    registry.add_observer(Boom())
+
+    registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    assert registry.get(handle.run_id).status is RunStatus.RUNNING
+
+
+# ── regression #4: metrics & provider_job_id fields ───────────────────
+
+
+def test_transition_updates_metrics_and_provider_job_id(
+    registry: RunRegistry,
+) -> None:
+    """Regression: the ProviderBatchBackend (§5) needs to persist the
+    provider's batch_id once a job is submitted (SUBMITTED_REMOTE).
+    Metrics (rows processed, cost so far) are updated on every
+    transition by the live executor. If transition dropped these,
+    the MCP ``ondine_status`` tool would show stale zeroes."""
+    handle = registry.create(RunSpec(pipeline_id=str(uuid4())))
+    registry.transition(handle.run_id, RunStatus.RUNNING)
+
+    updated = registry.transition(
+        handle.run_id,
+        RunStatus.SUBMITTED_REMOTE,
+        metrics={"rows": 1000, "cost": str(Decimal("0.42"))},
+        provider_job_id="batch_abc123",
+    )
+
+    assert updated.provider_job_id == "batch_abc123"
+    assert updated.metrics["rows"] == 1000
+    fresh = registry.get(handle.run_id)
+    assert fresh.provider_job_id == "batch_abc123"
+    assert fresh.metrics["cost"] == str(Decimal("0.42"))
+
+
+# ── regression #5: list filters & ordering ────────────────────────────
+
+
+def test_list_filters_by_status(registry: RunRegistry) -> None:
+    """Regression: the MCP ``ondine_status`` tool lists RUNNING jobs for
+    the dashboard. If list(status=) ignored the filter, the dashboard
+    would show terminal jobs forever and the user would never know a
+    run finished until they refreshed."""
+    h1 = registry.create(RunSpec(pipeline_id=str(uuid4())))
+    h2 = registry.create(RunSpec(pipeline_id=str(uuid4())))
+    h3 = registry.create(RunSpec(pipeline_id=str(uuid4())))
+
+    registry.transition(h2.run_id, RunStatus.RUNNING)
+    registry.transition(h3.run_id, RunStatus.RUNNING)
+    registry.transition(h3.run_id, RunStatus.SUCCEEDED)
+
+    assert {h.run_id for h in registry.list()} == {h1.run_id, h2.run_id, h3.run_id}
+    assert [h.run_id for h in registry.list(RunStatus.RUNNING)] == [h2.run_id]
+    assert [h.run_id for h in registry.list(RunStatus.PENDING)] == [h1.run_id]
+    assert registry.list(RunStatus.FAILED) == []
+
+
+def test_list_returns_newest_first(registry: RunRegistry) -> None:
+    """Regression: the CLI ``ondine status`` shows the most recent run
+    first. If list returned oldest-first, the user would scroll past
+    stale jobs to find their latest one."""
+    ids = [registry.create(RunSpec(pipeline_id=str(uuid4()))).run_id for _ in range(3)]
+    listed = [h.run_id for h in registry.list()]
+    assert listed == list(reversed(ids))
+
+
+# ── regression #6: spec_snapshot round-trip ───────────────────────────
+
+
+def test_spec_snapshot_roundtrips_arbitrary_dict(registry: RunRegistry) -> None:
+    """Regression: the spec snapshot is what resume relies on — without
+    it, a crashed ``provider_batch`` run could not be reattached by the
+    CLI. Losing nested keys would silently drop the prompt/model."""
+    snapshot = {
+        "pipeline_id": str(uuid4()),
+        "model": "gpt-4o-mini",
+        "prompt": "Summarize: {text}",
+        "nested": {"batch_size": 32, "columns": ["a", "b"]},
+    }
+    handle = registry.create(RunSpec.from_dict({"spec_snapshot": snapshot}))
+
+    fresh = registry.get(handle.run_id)
+    assert fresh.spec_snapshot == snapshot
+    assert fresh.spec_snapshot["nested"]["columns"] == ["a", "b"]
+
+
+# ── regression #7: Pipeline.execute(run_id=...) integration ──────────
+
+
+def _make_pipeline(
+    checkpoint_dir: Path,
+    *,
+    failing: bool = False,
+) -> tuple[Any, PipelineSpecifications, Any]:
+    """Build a minimal Pipeline with a mocked LLM client.
+
+    The mock returns deterministic responses so execute() succeeds
+    without network access — we only need the registry wire-up, not the
+    LLM behaviour (which has its own test suite).
+
+    When ``failing=True`` the mock client raises on every invoke and the
+    processing spec uses ``ErrorPolicy.FAIL`` so the error propagates
+    out of execute(). This exercises the real failure path instead of
+    inventing a ``fail_fast`` knob that would just shadow ErrorPolicy.
+    """
+    from unittest.mock import patch
+
+    from ondine.adapters.llm_client import LLMClient
+    from ondine.api.pipeline import Pipeline
+    from ondine.core.models import LLMResponse
+    from ondine.core.specifications import ErrorPolicy, ProcessingSpec
+
+    df = pd.DataFrame({"text": ["a", "b", "c"]})
+    processing = ProcessingSpec(
+        checkpoint_dir=checkpoint_dir,
+        cleanup_on_success=False,
+        progress_mode="none",
+        max_retries=0,
+        retry_delay=0.0,
+    )
+    if failing:
+        processing = processing.model_copy(update={"error_policy": ErrorPolicy.FAIL})
+
+    specs = PipelineSpecifications(
+        dataset=DatasetSpec(
+            source_type=DataSourceType.DATAFRAME,
+            input_columns=["text"],
+            output_columns=["result"],
+        ),
+        prompt=PromptSpec(template="{text}"),
+        llm=LLMSpec(
+            provider=LLMProvider.OPENAI,
+            model="gpt-4o-mini",
+            input_cost_per_1k_tokens=Decimal("0.00015"),
+            output_cost_per_1k_tokens=Decimal("0.0006"),
+        ),
+        processing=processing,
+    )
+
+    if failing:
+
+        class FailingClient(LLMClient):
+            def invoke(self, prompt, **kwargs):
+                raise RuntimeError("simulated provider failure")
+
+            async def ainvoke(self, prompt, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            def structured_invoke(self, prompt, output_cls, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            async def structured_invoke_async(self, prompt, output_cls, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            async def start(self):
+                pass
+
+            async def stop(self):
+                pass
+
+            def estimate_tokens(self, text):
+                return len(text) // 4
+
+        mock_client = FailingClient(specs.llm)
+    else:
+
+        class MockClient(LLMClient):
+            def invoke(self, prompt, **kwargs):
+                return LLMResponse(
+                    text="ok",
+                    tokens_in=1,
+                    tokens_out=1,
+                    model=self.model,
+                    cost=Decimal("0.0001"),
+                    latency_ms=1.0,
+                )
+
+            async def ainvoke(self, prompt, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            def structured_invoke(self, prompt, output_cls, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            async def structured_invoke_async(self, prompt, output_cls, **kwargs):
+                return self.invoke(prompt, **kwargs)
+
+            async def start(self):
+                pass
+
+            async def stop(self):
+                pass
+
+            def estimate_tokens(self, text):
+                return len(text) // 4
+
+        mock_client = MockClient(specs.llm)
+
+    pipeline = Pipeline(specs, dataframe=df)
+    patcher = patch(
+        "ondine.api.pipeline.create_llm_client",
+        return_value=mock_client,
+    )
+    patcher.start()
+    return pipeline, specs, patcher
+
+
+def test_pipeline_execute_with_run_id_registers_and_traces(
+    tmp_path: Path,
+) -> None:
+    """Regression: ``Pipeline.execute(run_id=...)`` must register the run
+    and trace its terminal state in the registry. Without the wire-up,
+    the MCP ``ondine_status`` tool would return PENDING forever for a
+    run that actually finished — a broken dashboard."""
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+    registry = RunRegistry(checkpoint_dir)
+    spec = RunSpec(
+        pipeline_id=str(uuid4()),
+        dataset="df",
+        spec_snapshot={"model": "gpt-4o-mini"},
+    )
+    handle = registry.create(spec)
+
+    pipeline, _, patcher = _make_pipeline(checkpoint_dir)
+    try:
+        pipeline.execute(run_id=handle.run_id, registry=registry)
+    finally:
+        patcher.stop()
+
+    final = registry.get(handle.run_id)
+    assert final is not None
+    assert final.status is RunStatus.SUCCEEDED
+    assert final.metrics["total_rows"] == 3
+
+
+def test_pipeline_execute_without_run_id_leaves_registry_empty(
+    tmp_path: Path,
+) -> None:
+    """Regression: the default path (run_id=None) must NOT touch the
+    registry. Existing users who never opted in would otherwise find a
+    ``runs.db`` file appearing in their checkpoint dir — a breaking
+    side-effect on every execute() call."""
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+    registry = RunRegistry(checkpoint_dir)
+
+    pipeline, _, patcher = _make_pipeline(checkpoint_dir)
+    try:
+        pipeline.execute()
+    finally:
+        patcher.stop()
+
+    registry2 = RunRegistry(checkpoint_dir)
+    try:
+        assert registry2.list() == []
+    finally:
+        registry.close()
+        registry2.close()
+
+
+def test_pipeline_execute_failure_records_failed_state(
+    tmp_path: Path,
+) -> None:
+    """Regression: when the pipeline raises, the registry must record
+    FAILED so the dashboard doesn't keep a dead run as RUNNING —
+    otherwise operators never know it died.
+
+    We exercise the real failure path: a mock LLM client that raises and
+    an ``ErrorPolicy.FAIL`` processing spec, so the error propagates out
+    of execute() exactly as a genuine provider outage would.
+    """
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+    registry = RunRegistry(checkpoint_dir)
+    spec = RunSpec(pipeline_id=str(uuid4()), dataset="df")
+    handle = registry.create(spec)
+
+    pipeline, _, patcher = _make_pipeline(checkpoint_dir, failing=True)
+    try:
+        with pytest.raises(Exception):
+            pipeline.execute(run_id=handle.run_id, registry=registry)
+    finally:
+        patcher.stop()
+
+    final = registry.get(handle.run_id)
+    assert final is not None
+    assert final.status is RunStatus.FAILED
+
+
+# ── fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> RunRegistry:
+    db_path = tmp_path / "runs.db"
+    r = RunRegistry(db_path)
+    yield r
+    r.close()


### PR DESCRIPTION
Completes architecture SS3+SS5 with a unified submit/poll/collect protocol.

- ProviderBatchBackend: OpenAI + Anthropic native Batch API (50% cost savings)
- LiveBackend: ported asyncio engine with degenerate lifecycle
- execution_mode field on ProcessingSpec (live|provider_batch)
- Pipeline.submit() + .attach(run_id)
- CLI: ondine submit/status/collect
- 13 LiveBackend unit tests + E2E DeepSeek test + 1006 full suite

This branch supersedes wt/t3-backend-extract (discarded due to protocol conflict)
and wt/t5-provider-batch (subsumed). Merge order: 4th (depends on t2+t4).